### PR TITLE
set a default value for the $errorContext parameter to support php-8.1+

### DIFF
--- a/debug.php.dist
+++ b/debug.php.dist
@@ -42,7 +42,7 @@ set_error_handler("grommunio_error_handler");
 * Custom error handler, here we check to see if it is a MAPI error and dump all info
 * to the dump file, and finally we redirect the error back to PHP
 */
-function grommunio_error_handler($errno, $errstr, $errfile, $errline, $errorContext)
+function grommunio_error_handler($errno, $errstr, $errfile, $errline, $errorContext = [])
 {
 	$error = array("msg"=>$errstr, "file"=>$errfile.":".$errline);
 


### PR DESCRIPTION
This parameter has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. If the function defines this parameter without a default, an error of "too few arguments" will be raised when it is called.