### PR TITLE
fix: insecure temporary file handling for thumbnail generation

### DIFF
--- a/server/includes/core/class.settings.php
+++ b/server/includes/core/class.settings.php
@@ -470,7 +470,7 @@ class Settings {
 				if (preg_match('/^data:image\/(?<extension>(?:png|gif|jpg|jpeg));base64,(?<image>.+)$/', $thumbnail_photo, $matchings)) {
 					$imageData = base64_decode($matchings['image']);
 					$extension = $matchings['extension'];
-					$tmp_file = "/tmp/thumbnail-" . time() . "." . $extension;
+					$tmp_file = tempnam(sys_get_temp_dir(), "thumbnail_");
 					if (file_put_contents($tmp_file, $imageData)) {
 						if (strcasecmp($extension, "gif") == 0) {
 							$im = imagecreatefromgif($tmp_file);


### PR DESCRIPTION
When an user saves his preferences in the grommunio web interface a avatar thumbnail is generated and written to a temporary file. The filename is derived from a static prefix, the current unix epoch timestamp and the image type. This corresponds to the common attack vector [CAPEC-149](https://capec.mitre.org/data/definitions/149.html) *Search for predictable names for temporary files*.

Without a specific intention, a race condition can occur between users who triggers a preview creation at the same time with a granularity of one second. This can lead to access corrupted or unexpected image data.

The temporary file is created in `/tmp` with world readable permissions. This corresponds to the common attack vector [CAPEC-155](https://capec.mitre.org/data/definitions/155.html) *Screen Temporary Files for Sensitive Information*. This is considered to have a low risk as it concerns only contact avatars, even if they are not available to the general public.