### PR TITLE
fix: world-writable shm used for translation caching

### DIFF
--- a/server/includes/core/class.language.php
+++ b/server/includes/core/class.language.php
@@ -184,7 +184,7 @@ class Language {
 	}
 
 	public function getTranslations() {
-		$memid = @shm_attach(0x950412DE, 16 * 1024 * 1024, 0666);
+		$memid = @shm_attach(0x950412DE, 16 * 1024 * 1024, 0644);
 		if (@shm_has_var($memid, 0)) {
 			$cache_table = @shm_get_var($memid, 0);
 			$selected_lang = $this->getSelected();


### PR DESCRIPTION
The translation cache is created world-writable allowing an unprivileged local attacker (OS level) to override the translation. I fear that this could possibly also be misused for code injection in the web frontend, but I did not checked it in detail.

```
------ Shared Memory Segments --------
key        shmid      owner      perms      bytes      nattch     status
0x950412de 0          groweb     666        16777216   0
```