### PR TITLE
fix: clear translation cache if no translation data was found

### DIFF
--- a/server/includes/core/class.language.php
+++ b/server/includes/core/class.language.php
@@ -196,15 +196,18 @@ class Language {
 			}
 			$translation_id = $cache_table[$selected_lang];
 			if (empty($translation_id)) {
+				@shm_remove_var($memid, 0);
 				@shm_detach($memid);
 
 				return ['grommunio_web' => []];
 			}
 			$translations = @shm_get_var($memid, $translation_id);
-			@shm_detach($memid);
 			if (empty($translations)) {
+				@shm_remove_var($memid, 0);
+				@shm_detach($memid);
 				return ['grommunio_web' => []];
 			}
+			@shm_detach($memid);
 
 			return $translations;
 		}


### PR DESCRIPTION
We observed missing translations after upgrades/reboots. It seems that the content of the lookup variable (`($memid, 0)`) was an empty array. Grommunio-web did not recover from this situation as it never clears the cache if the lookup table is empty, automatically. A workaround is to clear the cache using `ipcrm -M 0x950412de`, manually

This change clears the cache when the lookup variable is empty or the translation is not found. This allows to recover from a broken cache, automatically.