### PR TITLE
Import EML with synthesised receive-timestamp

### DIFF
--- a/server/includes/upload_attachment.php
+++ b/server/includes/upload_attachment.php
@@ -638,26 +638,11 @@ class UploadAttachment {
 		$newMessage = mapi_folder_createmessage($this->destinationFolder);
 		$addrBook = $GLOBALS['mapisession']->getAddressbook();
 		// Convert an RFC822-formatted e-mail to a MAPI Message
-		$ok = mapi_inetmapi_imtomapi($GLOBALS['mapisession']->getSession(), $this->store, $addrBook, $newMessage, $attachmentStream, []);
+		$ok = mapi_inetmapi_imtomapi($GLOBALS['mapisession']->getSession(), $this->store, $addrBook, $newMessage, $attachmentStream, ["add_rcvd_timestamp"=>1]);
 
 		if ($ok === true) {
-			// Manually set PR_MESSAGE_DELIVERY_TIME to sent time, since mapi_inetmapi_imtomapi does not set delivery-time
-			// Either use PR_CLIENT_SUBMIT_TIME or extract date from EML and set PR_MESSAGE_DELIVERY_TIME
-	 		$props = mapi_getprops($newMessage, [PR_CLIENT_SUBMIT_TIME, PR_MESSAGE_DELIVERY_TIME]);
-                        if (empty($props[PR_MESSAGE_DELIVERY_TIME])) {
-				if (!empty($props[PR_CLIENT_SUBMIT_TIME]))
-                                	mapi_setprops($newMessage, [PR_MESSAGE_DELIVERY_TIME => $props[PR_CLIENT_SUBMIT_TIME]]);
-				else {
-					if (preg_match('/^Date:\s*(.+)$/mi', $attachmentStream, $matches)) {
-                				$deliverytime = strtotime(trim($matches[1]));
-                				if ($deliverytime) 
-							mapi_setprops($newMessage, [PR_MESSAGE_DELIVERY_TIME => $deliverytime]);
-        
-        				}
-				}
-				mapi_message_savechanges($newMessage);
-			}
-		
+			mapi_message_savechanges($newMessage);
+
 			return bin2hex((string) mapi_getprops($newMessage, [PR_ENTRYID])[PR_ENTRYID]);
 		}
 


### PR DESCRIPTION
As RFC822 doesn't define a receive-time header ("`Date:`" reflects the submit-timestamp), EML-files are imported with undefined `PR_MESSAGE_DELIVERY_TIME `. In a usually receive-timestamp ordered mail-folder such imports appear in a not optimal sort-position at the beginning of time. This change, sets `PR_MESSAGE_DELIVERY_TIME `to `PR_CLIENT_SUBMIT_TIME `or, if not available, tries to parse the EMLs `Date`:-header.