### PR TITLE
Plugins: Files, smime: PHP8.5: Remove deprecated curl_close calls

### DIFF
--- a/plugins/files/php/Files/Backend/Webdav/class.backend.php
+++ b/plugins/files/php/Files/Backend/Webdav/class.backend.php
@@ -1079,7 +1079,6 @@ class Backend extends AbstractBackend implements iFeatureQuota, iFeatureVersionI
 		}
 		$versiondata = curl_exec($ch);
 		$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		curl_close($ch);
 
 		if ($httpcode && $httpcode == "200" && $versiondata) {
 			$versions = json_decode($versiondata);

--- a/plugins/filesbackendDefault/php/class.backend.php
+++ b/plugins/filesbackendDefault/php/class.backend.php
@@ -337,7 +337,6 @@ class Backend extends \Files\Backend\Webdav\Backend implements iFeatureSharing {
 		}
 		$versiondata = curl_exec($ch);
 		$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		curl_close($ch);
 
 		if ($httpcode && $httpcode == "200" && $versiondata) {
 			$versions = json_decode($versiondata);

--- a/plugins/filesbackendDefault/php/lib/ocsapi/class.ocsclient.php
+++ b/plugins/filesbackendDefault/php/lib/ocsapi/class.ocsclient.php
@@ -157,7 +157,6 @@ class ocsclient {
 		else {
 			$message = $httpcode;
 		}
-		curl_close($ch);
 
 		if ($httpcode && $httpcode == "200") {
 			$this->loaded = true;
@@ -263,7 +262,6 @@ class ocsclient {
 		curl_setopt($ch, CURLOPT_USERPWD, $this->user . ":" . $this->pass);
 		$responsedata = curl_exec($ch);
 		$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		curl_close($ch);
 
 		if ($httpcode === 200) {
 			try {

--- a/plugins/filesbackendSeafile/php/lib/seafapi/SeafileApi.php
+++ b/plugins/filesbackendSeafile/php/lib/seafapi/SeafileApi.php
@@ -1462,7 +1462,6 @@ final class SeafileApi {
 		}
 		$result = curl_exec($this->handle);
 		$this->curlExecHandleResult($result);
-		curl_close($this->handle);
 
 		return $result;
 	}

--- a/plugins/smime/php/class.certificate.php
+++ b/plugins/smime/php/class.certificate.php
@@ -285,7 +285,6 @@ class Certificate {
 		else {
 			Log::Write(LOGLEVEL_ERROR, sprintf("[smime] Error when downloading internmediate certificate '%s', http status: '%s'", $curl_error, $http_status));
 		}
-		curl_close($ch);
 
 		return new Certificate($cert);
 	}


### PR DESCRIPTION
Function `curl_close()` is deprecated since 8.5, as it has no effect since PHP 8.0.

(ref. https://www.php.net/manual/de/migration85.deprecated.php) 
The `curl_close()` function has been deprecated, as `CurlHandle `objects are freed automatically.