### PR TITLE
feat: add conversation view

### DIFF
--- a/client/resources/css/grommunio.css
+++ b/client/resources/css/grommunio.css
@@ -6396,6 +6396,89 @@ input.x-form-text.x-form-field.x-form-focus {
 .tox .tox-edit-area:before {
   border: 1px solid var(--theme-primary-color) !important;
 }
+
+/******************************************************************************
+ * Conversation (threaded) view
+ ******************************************************************************/
+/* Down arrow shown on an expanded conversation header */
+.line_arrow_down_l {
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSIxMiI+PHBhdGggZmlsbD0iIzIxMjEyMSIgZD0iTTIuMTQ4IDQuMTQ4YS40OTUuNDk1IDAgMCAxIC43MDQgMEw2IDcuMjkzbDMuMTQ4LTMuMTQ1YS40ODcuNDg3IDAgMCAxIC40ODUtLjEzNmMuMTc2LjA0My4zMTIuMTguMzU1LjM1NWEuNDg3LjQ4NyAwIDAgMS0uMTM2LjQ4NWwtMy41IDMuNWEuNDk1LjQ5NSAwIDAgMS0uNzA0IDBsLTMuNS0zLjVhLjQ5NS40OTUgMCAwIDEgMC0uNzA0Wm0wIDAiLz48L3N2Zz4=) !important;
+  background-repeat: no-repeat !important;
+  background-position: center center !important;
+}
+
+/* Position the expand/collapse arrow at the left of a conversation header row */
+.x-grid3-row.k-conversation-header.k-depth-0.arrow_right_l,
+.x-grid3-row.k-conversation-header.k-depth-0.line_arrow_down_l {
+  background-size: 12px !important;
+  background-position: 10px 18px !important;
+  cursor: pointer;
+}
+
+/* Compact (right preview) header arrow sits a little higher */
+.x-grid3-row.k-conversation-header.k-depth-0.k-compact-row.arrow_right_l,
+.x-grid3-row.k-conversation-header.k-depth-0.k-compact-row.line_arrow_down_l {
+  background-position: 10px 14px !important;
+}
+
+/* The conversation count next to the header subject */
+.x-grid3-row.k-conversation-header .k-conversation-count {
+  font-weight: bold;
+  padding-left: 2px;
+}
+
+/* Conversation header rows should not show a context menu cursor on the body */
+.x-grid3-row.k-conversation-header {
+  cursor: pointer;
+}
+
+/* Indentation of conversation child items */
+.x-grid3-row.k-depth-1 .x-grid3-cell-inner {
+  padding-left: 30px;
+}
+.x-grid3-row.k-depth-1 .x-grid3-row-body {
+  padding-left: 30px;
+}
+.x-grid3-row.k-depth-1 .k-icon {
+  float: left;
+  width: 20px;
+  height: 20px;
+  padding-right: 6px;
+  background-position-x: left !important;
+}
+
+/* Thread lines connecting conversation child items.
+   A vertical line is drawn on the left with a node marker per item. */
+.x-grid3-row.k-depth-1.line_circle_l,
+.x-grid3-row.k-depth-1.line_circle_end {
+  background-image:
+    radial-gradient(circle at 14px 50%, var(--theme-primary-color, #2882d7) 0, var(--theme-primary-color, #2882d7) 3px, transparent 4px),
+    linear-gradient(var(--theme-border-color, #c9ced6), var(--theme-border-color, #c9ced6));
+  background-repeat: no-repeat, no-repeat;
+}
+/* Middle item: line spans the full height of the row */
+.x-grid3-row.k-depth-1.line_circle_l {
+  background-position: left center, 13px 0;
+  background-size: auto, 2px 100%;
+}
+/* Last item: line stops at the node marker */
+.x-grid3-row.k-depth-1.line_circle_end {
+  background-position: left center, 13px 0;
+  background-size: auto, 2px 50%;
+}
+
+/* Container for the conversation header arrow in right preview mode */
+.zarafa-grid-body-container .k-conversation-icon-container {
+  position: absolute;
+  padding-top: 4px;
+}
+.zarafa-grid-body-container .k-conversation-icon-container .k-conversation-icon {
+  display: block;
+  padding: 0 1.5px;
+  width: 23px;
+  height: 15px;
+  cursor: pointer;
+}
 /*# sourceMappingURL=grommunio.css.map */
 
 

--- a/client/zarafa/mail/MailRecord.js
+++ b/client/zarafa/mail/MailRecord.js
@@ -29,7 +29,10 @@ Zarafa.mail.MailRecordFields = [
 	{name: 'stubbed', type: 'boolean', defaultValue: false},
 	{name: 'startdate', type: 'date', dateFormat: 'timestamp', defaultValue: null},
 	{name: 'duedate', type: 'date', dateFormat: 'timestamp', defaultValue: null},
-	{name: 'user_image', type: 'string'}
+	{name: 'user_image', type: 'string'},
+	{name: 'depth', type: 'int', defaultValue: 0},
+	{name: 'conversation_count', type: 'int', defaultValue: 0},
+	{name: 'folder_name'}
 ];
 
 Zarafa.mail.MailRecordPhantomHandler = function(record) {

--- a/client/zarafa/mail/MailStore.js
+++ b/client/zarafa/mail/MailStore.js
@@ -1,3 +1,6 @@
+/*
+ * #dependsFile client/zarafa/mail/data/ConversationManagers.js
+ */
 Ext.namespace('Zarafa.mail');
 
 /**
@@ -26,7 +29,8 @@ Zarafa.mail.MailStore = Ext.extend(Zarafa.core.data.ListModuleStore, {
 			defaultSortInfo: {
 				field: 'message_delivery_time',
 				direction: 'desc'
-			}
+			},
+			conversationManager: new Zarafa.mail.data.ConversationManagers()
 		});
 
 		Zarafa.mail.MailStore.superclass.constructor.call(this, config);
@@ -143,6 +147,258 @@ Zarafa.mail.MailStore = Ext.extend(Zarafa.core.data.ListModuleStore, {
 	},
 
 	/**
+	 * Used to check if this store contains conversations. (records grouped by conversation and
+	 * prefixed with conversation header records)
+	 *
+	 * @return {Boolean} True if the store contains conversations, or false otherwise.
+	 */
+	containsConversations: function()
+	{
+		// Check if the user enabled conversation view in his settings
+		if (container.isEnabledConversation() === false) {
+			return false;
+		}
+
+		// Check if the user is using infinite scroll
+		var infiniteScrollEnabled = container.getSettingsModel().get('zarafa/v1/contexts/mail/enable_live_scroll');
+		if (!infiniteScrollEnabled) {
+			return false;
+		}
+
+		// Check if this store contains the inbox. It is the only folder that can be rendered
+		// with conversation view.
+		var inbox = container.getHierarchyStore().getDefaultFolder('inbox');
+		if (!inbox) {
+			return false;
+		}
+		return (Zarafa.core.EntryId.compareEntryIds(this.entryId, inbox.get('entryid')));
+	},
+
+	/**
+	 * Checks if the given record is part of an expanded conversation
+	 *
+	 * @param {Zarafa.mail.MailRecord} record The record that should be checked
+	 * @return {Boolean} True is the record is part of an expanded conversation,
+	 * false otherwise
+	 */
+	isConversationOpened: function(record)
+	{
+		var openedRecordManager = this.conversationManager.getOpenedRecordManager();
+		var openedItems = Ext.flatten(openedRecordManager.getRange());
+
+		var entryId = record.get('entryid');
+		return openedRecordManager.containsKey(entryId) || openedItems.indexOf(entryId) !== -1;
+	},
+
+	/**
+	 * Function will be called on 'load' event of store. It will manage the open/close state of
+	 * header records and filter the store to not show items in conversations that have not been
+	 * expanded.
+	 *
+	 * @param {Zarafa.mail.MailStore} store which contains message records
+	 * @param {Zarafa.mail.MailRecord[]} records array which holds all the records we received in load request.
+	 */
+	manageOpenConversations: function(store, records)
+	{
+		if (container.isEnabledConversation() === false) {
+			return;
+		}
+
+		var openedRecordManager = this.conversationManager.getOpenedRecordManager();
+		var openedItems = Ext.flatten(openedRecordManager.getRange());
+
+		for (var i = 0; i < records.length - 1; i++) {
+			var currentRecord = records[i];
+			var currRecordConversationCount = currentRecord.get('conversation_count');
+
+			var isConversationOpened = function(item) {
+				var entryId = item.get("entryid");
+				return openedRecordManager.containsKey(entryId) || openedItems.indexOf(entryId) !== -1;
+			};
+
+			// Proceed only if currentRecord is a Header record.
+			// We only need to alter the open/close state of currentRecord on the basis of its last
+			// conversation item's state, because there can be newly added items which might not be
+			// in openedRecordManager.
+			if (currRecordConversationCount > 0) {
+				var isAnyItemOpened = false;
+				var unOpenedItems = [];
+
+				// Loop through all conversation items of the current conversation. If any opened
+				// item is found that means a conversation was opened before, so add all unopened
+				// items (i.e. newly received mail, restored mail, header record) into the manager.
+				for (var j = i; j <= i + currRecordConversationCount; j++) {
+					var conversationItem = records[j];
+					if (isConversationOpened(conversationItem)) {
+						isAnyItemOpened = true;
+						continue;
+					}
+					unOpenedItems.push(conversationItem.get('entryid'));
+				}
+
+				// If any conversation item is found open then add unopened items to the manager.
+				if (isAnyItemOpened) {
+					var items = unOpenedItems;
+					if (isConversationOpened(currentRecord)) {
+						items = openedRecordManager.get(currentRecord.get('entryid')).concat(unOpenedItems);
+					}
+					openedRecordManager.add(currentRecord.get('entryid'), items);
+				} else if (!isAnyItemOpened && isConversationOpened(currentRecord)) {
+					openedRecordManager.removeKey(currentRecord.get('entryid'));
+				}
+
+				// Jump to the next record after a conversation finished.
+				i = i + currRecordConversationCount;
+			}
+		}
+
+		this.filterByConversations();
+	},
+
+	/**
+	 * Filters the store to not show items in conversations that have not been expanded
+	 */
+	filterByConversations: function()
+	{
+		if (container.isEnabledConversation() === false) {
+			return;
+		}
+
+		var openedRecordManager = this.conversationManager.getOpenedRecordManager();
+		var openedItems = Ext.flatten(openedRecordManager.getRange());
+
+		this.filterBy(function(openedItems, openedRecordManager, record, entryId) {
+			return record.get('depth') === 0 || openedRecordManager.containsKey(entryId) === true || openedItems.indexOf(entryId) !== -1;
+		}.bind(this, openedItems, openedRecordManager), this);
+	},
+
+	/**
+	 * Function toggles the conversation.
+	 *
+	 * @param {Zarafa.core.IPMRecord} headerRecord The header record of conversation.
+	 * @param {Boolean} expand The expand is true if conversation needs to expand else false.
+	 */
+	toggleConversation: function(headerRecord, expand)
+	{
+		if (!headerRecord.isConversationHeaderRecord()) {
+			return;
+		}
+		var headerRecordEntryId = headerRecord.get('entryid');
+		var openedRecordManager = this.conversationManager.getOpenedRecordManager();
+		var hide = Ext.isDefined(expand) ? !expand : openedRecordManager.containsKey(headerRecordEntryId);
+
+		if (hide) {
+			openedRecordManager.removeKey(headerRecordEntryId);
+		} else {
+			this.clearFilter(true);
+			var rowIndex = this.indexOf(headerRecord);
+			var conversationCount = headerRecord.get('conversation_count');
+			var records = this.getRange(rowIndex + 1, rowIndex + conversationCount);
+
+			var recordIDs = Ext.pluck(records, "id");
+			openedRecordManager.add(headerRecordEntryId, recordIDs);
+		}
+
+		this.filterByConversations();
+	},
+
+	/**
+	 * Function will collapse all the conversation except the given header record in parameter
+	 * and if no header record is provided then it will collapse all the conversation.
+	 *
+	 * @param {Zarafa.core.IPMRecord} headerRecord The header record of conversation.
+	 */
+	collapseAllConversation: function(headerRecord)
+	{
+		this.conversationManager.closeAll(headerRecord);
+		this.filterByConversations();
+	},
+
+	/**
+	 * Helper function to open (expand) a conversation
+	 *
+	 * @param {Zarafa.mail.MailRecord} headerRecord
+	 */
+	expandConversation: function(headerRecord)
+	{
+		this.toggleConversation(headerRecord, true);
+	},
+
+	/**
+	 * Returns all the records in the store that are part of the conversation identified
+	 * by the given header record
+	 *
+	 * @param {Zarafa.core.data.MapiRecord} headerRecord The header record of the conversation
+	 * @return {Zarafa.core.data.MapiRecord[]} The records that belong to the requested conversation
+	 */
+	getConversationItemsFromHeaderRecord: function(headerRecord)
+	{
+		var items = this.snapshot || this.data;
+		var index = items.findIndex('id', headerRecord.id) + 1;
+		var retVal = [];
+		var item;
+		while ((item = items.get(index)) && item.get('depth') > 0) {
+			retVal.push(item);
+			index++;
+		}
+
+		return retVal;
+	},
+
+	/**
+	 * Returns header record identified by the given record item which is part of that conversation.
+	 * Or it returns false if given record is not part of any conversation.
+	 *
+	 * @param {Zarafa.core.data.MapiRecord} record The conversation item record whose header record needs to be found.
+	 * @return {Zarafa.core.data.MapiRecord} returns header record for the given conversation item
+	 * or false if given record is not part of any conversation.
+	 */
+	getHeaderRecordFromItem: function(record)
+	{
+		if (!Ext.isDefined(record) || record.isNormalRecord()) {
+			return false;
+		} else if (record.isConversationHeaderRecord()) {
+			return record;
+		}
+
+		var items = this.snapshot || this.data;
+		var index = items.findIndex('id', record.id) - 1;
+		var headerRecord = false;
+		var item;
+		while ((item = items.get(index))) {
+			if (item.get('depth') === 0 && item.get('conversation_count') > 0) {
+				headerRecord = item;
+				break;
+			}
+			index--;
+		}
+
+		return headerRecord;
+	},
+
+	/**
+	 * Returns the number of conversations that are contained by the store
+	 *
+	 * @return {Number} Number of conversation in the store
+	 */
+	getConversationCount: function()
+	{
+		if (!this.containsConversations()) {
+			return 0;
+		}
+
+		var count = 0;
+		var items = this.snapshot ? this.snapshot.items : this.getRange();
+		items.forEach(function(item) {
+			if (item.get('depth') === 0) {
+				count++;
+			}
+		});
+
+		return count;
+	},
+
+	/**
 	 * Returns the number of items that have the store has
 	 * corresponds as a parent folder. (i.e. for conversations it will only
 	 * count the items from the Inbox folder and not the items from the Sent Items
@@ -152,19 +408,19 @@ Zarafa.mail.MailStore = Ext.extend(Zarafa.core.data.ListModuleStore, {
 	 */
 	getStoreLength: function()
 	{
-		// Get all items count when 'Unread' filtered has been applied.
-		// It looks like the code below is only necessary for conversation view.
-		// if (!this.hasFilterApplied) {
-		// 	var count = 0;
-		// 	var items = this.snapshot ? this.snapshot.items : this.getRange();
-		// 	items.forEach(function(item) {
-		// 		if (item.get('folder_name') === 'inbox') {
-		// 			count++;
-		// 		}
-		// 	});
+		// For conversations only count the items from the Inbox folder (not the Sent Items)
+		// and not the conversation header records. Only relevant when no filter is applied.
+		if (this.containsConversations() && !this.hasFilterApplied) {
+			var count = 0;
+			var items = this.snapshot ? this.snapshot.items : this.getRange();
+			items.forEach(function(item) {
+				if (item.get('folder_name') === 'inbox') {
+					count++;
+				}
+			});
 
-		// 	return count;
-		// }
+			return count;
+		}
 
 		return Zarafa.mail.MailStore.superclass.getStoreLength.apply(this, arguments);
 	},

--- a/client/zarafa/mail/settings/SettingsMailCategory.js
+++ b/client/zarafa/mail/settings/SettingsMailCategory.js
@@ -63,6 +63,8 @@ Zarafa.mail.settings.SettingsMailCategory = Ext.extend(Zarafa.settings.ui.Settin
 			{
 				xtype: 'zarafa.settingsincomingmailwidget'
 			},{
+				xtype: 'zarafa.settingsconversationwidget'
+			},{
 				xtype: 'zarafa.settingssignatureswidget',
 				settingsMailCategory: this
 			},

--- a/client/zarafa/mail/ui/MailGrid.js
+++ b/client/zarafa/mail/ui/MailGrid.js
@@ -132,9 +132,11 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 			scope: this
 		});
 
+		this.mon(this.getView(), 'beforelivescrollstart', this.onBeforeLiveScrollStart, this);
 		this.mon(this.getView(), 'livescrollstart', this.onLiveScrollStart, this);
 		this.mon(this.getView(), 'beforesort', this.onBeforeSort, this);
 
+		this.mon(this.getSelectionModel(), 'beforerowselect', this.onBeforeRowSelect, this);
 		// Add a buffer to the following 2 event handlers. These are influenced by Extjs when a record
 		// is removed from the store. However removing of records isn't performed in batches. This means
 		// that we need to offload the event handlers attached to removing of records in case that
@@ -153,6 +155,31 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 		this.mon(this.context, 'viewmodechange', this.onContextViewModeChange, this);
 		this.mon(this.context, 'viewchange', this.onContextViewChange, this);
 		this.onContextViewModeChange(this.context, this.context.getCurrentViewMode());
+
+		var store = this.getStore();
+		store.filterByConversations();
+		this.mon(store, 'load', store.manageOpenConversations, store);
+		this.mon(store, 'add', store.filterByConversations, store);
+		this.mon(store, 'remove', this.manageDeleteConversations, this);
+
+		this.mon(this.getView(), 'rowupdated', function(view, rowIndex, record) {
+			if (record.get('depth') === 0) {
+				return;
+			}
+
+			// Update the conversation header (to reflect read/unread status and flags)
+			var headerStore = record.getStore();
+			var i = rowIndex;
+			var r;
+			do {
+				i--;
+				r = headerStore.getAt(i);
+			} while (r && r.get('depth') > 0);
+
+			if (r) {
+				view.refreshRow(r);
+			}
+		}, this);
 	},
 
 	/**
@@ -215,30 +242,91 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 	 */
 	viewConfigGetRowClass : function(record, rowIndex, rowParams, store)
 	{
-		var cssClass = (Ext.isFunction(record.isRead) && !record.isRead() ? 'mail_unread' : 'mail_read');
+		var cssClass = this.grid.getConversationCssClasses(record, rowIndex, store);
 
 		if (this.enableRowBody) {
 			var meta = {}; // Metadata object for Zarafa.common.ui.grid.Renderers.
 			var value = ''; // The value which must be rendered
 			rowParams.body = '<div class="zarafa-grid-body-container">';
 
-			// Render the categories
-			cssClass += ' with-categories';
-			var categories = Zarafa.common.categories.Util.getCategories(record);
-			var categoriesHtml = Zarafa.common.categories.Util.getCategoriesHtml(categories);
-			rowParams.body += '<div class="k-category-add-container"><span class="k-category-add"></span></div><div class="k-category-container">' + categoriesHtml + '</div>';
+			if (record.isConversationHeaderRecord()) {
+				/**
+				 * Add container for conversation header arrow icons.
+				 *
+				 * Note: This is just an empty container to position the arrow icons background images
+				 * and to handle on arrow click actions for right preview mode.
+				 */
+				rowParams.body += '<div class="k-conversation-icon-container"><span class="k-conversation-icon"></span></div>';
+			} else {
+				// Render the categories
+				cssClass += ' with-categories';
+				var categories = Zarafa.common.categories.Util.getCategories(record);
+				var categoriesHtml = Zarafa.common.categories.Util.getCategoriesHtml(categories);
+				rowParams.body += '<div class="k-category-add-container"><span class="k-category-add"></span></div><div class="k-category-container">' + categoriesHtml + '</div>';
+			}
 
 			// Render the subject
 			meta = {};
-			value = Zarafa.common.ui.grid.Renderers.subject(record.get('subject'), meta, record);
+			if (record.isConversationRecord()) {
+				value = Zarafa.common.ui.grid.Renderers.body(record.get('body'), meta, record);
+			} else {
+				value = Zarafa.common.ui.grid.Renderers.subject(record.get('subject'), meta, record);
+			}
 			rowParams.body += String.format('<div class="grid_compact grid_compact_left grid_compact_subject_cell {0}">{1}</div>', meta.css, value);
 
 			rowParams.body += '</div>';
+			cssClass += ' k-compact-row';
 
 			return 'x-grid3-row-expanded ' + cssClass;
 		}
 
 		return 'x-grid3-row-collapsed ' + cssClass;
+	},
+
+	/**
+	 * Helper function to get css classes related to conversation view.
+	 *
+	 * @param {Ext.data.Record} record The {@link Ext.data.Record Record} corresponding to the current row.
+	 * @param {Number} rowIndex The row index
+	 * @param {Ext.data.Store} store The Ext.data.Store this grid is bound to
+	 * @return {String} css classes related to conversation item.
+	 */
+	getConversationCssClasses: function(record, rowIndex, store)
+	{
+		var isConversationHeader = record.isConversationHeaderRecord();
+		var depth = record.get('depth');
+		var cssClass = (Ext.isFunction(record.isRead) && !record.isRead() ? 'mail_unread' : 'mail_read');
+
+		// Conversation headers should get the read/unread info from the items in the conversation
+		if (isConversationHeader) {
+			cssClass = 'mail_read';
+			var conversationRecords = store.getConversationItemsFromHeaderRecord(record);
+			conversationRecords.every(function(r) {
+				if (Ext.isFunction(r.isRead) && !r.isRead()) {
+					cssClass = 'mail_unread';
+					return false;
+				}
+				return true;
+			});
+
+			cssClass += ' k-conversation-header';
+
+			cssClass += store.isConversationOpened(record) ? ' line_arrow_down_l' : ' arrow_right_l';
+
+		} else if (record.isConversationRecord()) {
+			// If its last item of the conversation.
+			if (store.getCount() === rowIndex + 1 ||
+				store.getAt(rowIndex+1).get('normalized_subject') !== record.get('normalized_subject') ||
+				store.getAt(rowIndex+1).get('depth') === 0) {
+				cssClass += ' line_circle_end k-last-conversation-item';
+			} else {
+				cssClass += ' line_circle_l';
+			}
+		}
+
+		cssClass += ' k-depth-' + depth;
+
+		return cssClass;
 	},
 
 	/**
@@ -388,9 +476,30 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 			return;
 		}
 
+		// Expand and collapse the conversation by clicking on arrow icon.
+		if (record.isConversationHeaderRecord()) {
+			// toggle the conversation by clicking on the arrow icon of conversation header.
+			if (columnIndex === 0) {
+				var headerStore = this.store;
+				headerStore.toggleConversation(record);
+				// If conversation is open then select first record from the
+				// conversation items.
+				if (headerStore.isConversationOpened(record)) {
+					grid.selModel.selectRow(rowIndex + 1, false);
+					if (this.expandSingleConversation) {
+						record.getStore().collapseAllConversation(record);
+					}
+				}
+			}
+			return false;
+		}
+
 		var cm = this.getColumnModel();
 		var column = cm.config[columnIndex];
-		if (column.dataIndex === 'icon_index') {
+		if (
+			column.dataIndex === 'icon_index' && !(Ext.isFunction(record.isConversationRecord) && record.isConversationRecord()) ||
+			column.dataIndex === 'sent_representing_name' && Ext.isFunction(record.isConversationRecord) && record.isConversationRecord() && Ext.fly(e.target).hasClass('k-icon')
+		) {
 			Zarafa.common.Actions.markAsRead(record, !record.isRead());
 		} else if(column.dataIndex === 'flag_due_by') {
 			Zarafa.common.Actions.openFlagsMenu(record, e.getXY());
@@ -408,16 +517,50 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 	 */
 	onRowClick : function(grid, rowIndex, event)
 	{
-		var record;
+		var store = this.store;
+		var keepExisting = event.ctrlKey || event.shiftKey;
+		// Get the record from the rowIndex
+		var record = store.getAt(rowIndex);
+
+		if ( Ext.get(event.target).hasClass('k-conversation-icon') ){
+			store.toggleConversation(record);
+			return;
+		}
+
+		if (record.isConversationHeaderRecord()) {
+			this.openConversation(record);
+		} else if (this.expandSingleConversation && !(keepExisting)) {
+			// close all opened conversation when user click on non conversation item.
+			var headerRecord = record.isConversationRecord() ? store.getHeaderRecordFromItem(record) : false;
+			store.collapseAllConversation(headerRecord);
+		}
 
 		if ( Ext.get(event.target).hasClass('k-category-add') ){
-			// Get the record from the rowIndex
-			record = this.store.getAt(rowIndex);
-
 			Zarafa.common.Actions.openCategoriesMenu([record], event.getXY());
 		}
 	},
 
+
+	/**
+	 * Event handler which is triggered when the user opens the context menu.
+	 * Overridden to make sure that right-clicks on conversation headers do not
+	 * generate a context menu.
+	 *
+	 * @param {Zarafa.mail.ui.MailGrid} grid The grid which was right clicked
+	 * @param {Number} rowIndex The index number of the row which was right clicked
+	 * @param {Number} cellIndex The index number of the column which was right clicked
+	 * @param {Ext.EventObject} event The event structure
+	 * @private
+	 */
+	onCellContextMenu: function(grid, rowIndex, cellIndex, event)
+	{
+		var record = this.store.getAt(rowIndex);
+		if (record && record.isConversationHeaderRecord()) {
+			return false;
+		}
+
+		return Zarafa.mail.ui.MailGrid.superclass.onCellContextMenu.call(this, grid, rowIndex, cellIndex, event);
+	},
 
 	/**
 	 * Event handler which is triggered when the user opens the context menu.
@@ -433,6 +576,11 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 	 */
 	onRowBodyContextMenu: function(grid, rowIndex, event)
 	{
+		var record = this.store.getAt(rowIndex);
+		if (record && record.isConversationHeaderRecord()) {
+			return false;
+		}
+
 		this.onCellContextMenu(grid, rowIndex, -1, event);
 	},
 
@@ -465,6 +613,45 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 	},
 
 	/**
+	 * Event handler before the row selection performs. If selected record is
+	 * conversation header then cancel the selection.
+	 *
+	 * @param {Zarafa.mail.ui.MailRowSelectionModel} selectionModel The selectionModel
+	 * @param {Number} rowIndex Then index to be selected.
+	 * @param {Boolean} keepExisting False if other selections will be cleared
+	 * @param {Zarafa.core.data.IPMRecord} record The record to be selected
+	 */
+	onBeforeRowSelect: function(selectionModel, rowIndex, keepExisting, record)
+	{
+		if (record.isConversationHeaderRecord()) {
+			this.openConversation(record, selectionModel, rowIndex, keepExisting);
+			return false;
+		}
+	},
+
+	/**
+	 * Function will expand the conversation if closed and select the first item of it.
+	 *
+	 * @param {Zarafa.core.data.IPMRecord} record The record needs to expand.
+	 * @param {Zarafa.mail.ui.MailRowSelectionModel} selectionModel The selectionModel
+	 * @param {Number} rowIndex Then index to be selected.
+	 * @param {Boolean} keepExisting False if other selections will be cleared
+	 */
+	openConversation: function(record, selectionModel, rowIndex, keepExisting)
+	{
+		var store = this.getStore();
+		if (!store.isConversationOpened(record)) {
+			store.expandConversation(record);
+			if (selectionModel) {
+				selectionModel.selectRow(rowIndex+1, keepExisting);
+			}
+			if (this.expandSingleConversation) {
+				store.collapseAllConversation(record);
+			}
+		}
+	},
+
+	/**
 	 * Helper function used to check {@link Zarafa.mail.settings.SettingsConversationWidget#enableConversations enabled conversation view }
 	 * and {@link Zarafa.mail.settings.SettingsConversationWidget#singleExpand single expand conversation} user setting enabled.
 	 *
@@ -490,14 +677,15 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 	onRowSelect: function(selectionModel, rowNumber, record)
 	{
 		var count = selectionModel.getCount();
-		//var conversationCount = record.get('conversation_count');
-		//var depth = record.get('depth');
 
-		if (count === 0) {
-		        this.cancelPreviewRecordTask();
-		        this.model.setPreviewRecord(undefined);
+		if (Ext.isFunction(record.isConversationHeaderRecord) && record.isConversationHeaderRecord()) {
+			this.cancelPreviewRecordTask();
+			this.model.setPreviewRecord(undefined);
+		} else if (count === 0) {
+			this.cancelPreviewRecordTask();
+			this.model.setPreviewRecord(undefined);
 		} else if (count === 1 && selectionModel.getSelected() === record) {
-		        this.queuePreviewRecord(record);
+			this.queuePreviewRecord(record);
 		}
 	},
 
@@ -578,6 +766,16 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 	},
 
 	/**
+	 * Event handler triggered before the live scroll start.
+	 */
+	onBeforeLiveScrollStart: function()
+	{
+		if (this.store.getStoreLength() >= this.store.getTotalCount()) {
+			return false;
+		}
+	},
+
+	/**
 	 * Event handler which triggered when scrollbar gets scrolled more then 90% of it`s height.
 	 * it will be used to start live scroll on {@link Zarafa.core.data.ListModuleStore ListModuleStore}.
 	 * also it will register event on {@link Zarafa.core.data.ListModuleStore ListModuleStore} to get
@@ -624,6 +822,69 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 	hasEnabledGrouping: function ()
 	{
 		return container.getSettingsModel().get('zarafa/v1/contexts/mail/enable_grouping');
+	},
+
+	/**
+	 * Function will Filter the store to not show items in conversations that have not been expanded
+	 * and will update {@link Zarafa.mail.data.ConversationManagers#getOpenedRecordManager openedConversationManager}
+	 * with deleted conversation Header.
+	 *
+	 * @param {Zarafa.mail.MailStore} store which contains message records
+	 * @param {Zarafa.mail.MailRecord} record which is deleted.
+	 */
+	manageDeleteConversations: function(store, record)
+	{
+		if(container.isEnabledConversation() === false || !record.isConversationRecord()) {
+			return;
+		}
+
+		var openedRecordManager = store.conversationManager.getOpenedRecordManager();
+		var rowSelectionModel = this.getSelectionModel();
+		var lastIndex = rowSelectionModel.lastActive;
+		var deleteWholeConversation = [];
+		// Iterate over the each conversation and check deleted record is part of any opened
+		// conversation.
+		openedRecordManager.eachKey(function (key, items, record, store, deleteWholeConversation) {
+			var index = items.indexOf(record.get("entryid"));
+			if( index > -1) {
+				items.splice(index, 1);
+				if(items.length > 0) {
+					// Check conversation has inbox item.
+					var hasInboxItem = items.some(function (item) {
+						return store.getById(item).get('folder_name') === "inbox";
+					});
+					if (hasInboxItem === false) {
+						deleteWholeConversation.push(key);
+					}
+				} else {
+					// Remove the conversation header key when no item left in the conversation.
+					deleteWholeConversation.push(key);
+				}
+				return false;
+			}
+			return true;
+		}.createDelegate(this, [record, store, deleteWholeConversation], 2), this);
+
+		// Remove whole conversation when conversation doesn't contains
+		// any inbox item.
+		if (!Ext.isEmpty(deleteWholeConversation)) {
+			for (var conversation of deleteWholeConversation) {
+				openedRecordManager.removeKey(conversation);
+				var headerRecord = store.getById(conversation);
+				var headerRecordIndex = store.indexOf(headerRecord);
+
+				// Store the lastActive index value when a header of last selected Row is going to be removed.
+				if (headerRecordIndex === lastIndex-1) {
+					rowSelectionModel.updatedLast = headerRecordIndex;
+				}
+
+				// Also remove conversation header record from store.
+				// Note: As conversation header row can not be selected to perform deletion on it,
+				// there will not be save request from store for the header record.
+				store.remove(headerRecord);
+			}
+		}
+		store.filterByConversations();
 	},
 
 	/**

--- a/client/zarafa/settings/data/SettingsDefaultValues.js
+++ b/client/zarafa/settings/data/SettingsDefaultValues.js
@@ -614,6 +614,20 @@ Zarafa.settings.data.SettingsDefaultValue = function(){
 								'enable_live_scroll': true,
 
 								/**
+								 * zarafa/v1/contexts/mail/enable_conversation_view
+								 * @property
+								 * @type Boolean
+								 */
+								'enable_conversation_view': false,
+
+								/**
+								 * zarafa/v1/contexts/mail/expand_single_conversation
+								 * @property
+								 * @type Boolean
+								 */
+								'expand_single_conversation': false,
+
+								/**
 								 * zarafa/v1/contexts/mail/readreceipt_handling
 								 * @property
 								 * @type Number

--- a/server/includes/modules/class.maillistmodule.php
+++ b/server/includes/modules/class.maillistmodule.php
@@ -1,5 +1,17 @@
 <?php
 
+// Maximum number of items that will be fetched to create conversations
+define('CONVERSATION_MAXFETCH', 1500);
+// Number of conversations that will be fetched per batch
+// (Conversations will be fetched in batches)
+define('CONVERSATION_BATCH_COUNT', 25);
+// Maximum number of items in a conversation that will be returned in the list response.
+// Others can be fetched later.
+define('CONVERSATION_MAXITEMS', 300000);
+// Time difference (in seconds) to decide whether to include an item in an existing
+// conversation or to create a new conversation. (3 months = 3600*24*30*3)
+define('MAX_TIME_DIFF', 7776000);
+
 /**
  * Mail Module.
  */
@@ -18,6 +30,17 @@ class MailListModule extends ListModule {
 	private $currentActionData;
 
 	/**
+	 * True when the mail list should be returned grouped as conversations.
+	 */
+	private $showAsConversations = false;
+
+	/**
+	 * State object used to keep track of the conversation batches while
+	 * the user scrolls through the (infinite scroll) mail list.
+	 */
+	private $state;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int   $id   unique id
@@ -25,7 +48,21 @@ class MailListModule extends ListModule {
 	 */
 	public function __construct($id, $data) {
 		parent::__construct($id, $data);
+		$this->showAsConversations = $this->useConversationView();
 		$this->properties = $GLOBALS["properties"]->getMailListProperties();
+	}
+
+	/**
+	 * Checks if the list should be returned as conversations or as a plain list.
+	 *
+	 * @return bool true if the list should be returned as conversations, false otherwise
+	 */
+	public function useConversationView() {
+		// Conversation view also requires live scroll to be enabled, because the
+		// conversations are fetched in batches while the user scrolls.
+		return
+			$GLOBALS['settings']->get('zarafa/v1/contexts/mail/enable_conversation_view') === true &&
+			$GLOBALS['settings']->get('zarafa/v1/contexts/mail/enable_live_scroll') !== false;
 	}
 
 	/**
@@ -175,6 +212,750 @@ class MailListModule extends ListModule {
 		}
 
 		return $this->_inboxTotalUnread;
+	}
+
+	/**
+	 * Retrieves a list of messages for a folder.
+	 *
+	 * Overridden to group the messages of the Inbox as conversations when the
+	 * conversation view is enabled. For all other cases the default (plain) list
+	 * of the parent class is returned.
+	 *
+	 * @param object $store      MAPI message store object
+	 * @param string $entryid    entryid of the folder
+	 * @param array  $action     the action data, sent by the client
+	 * @param string $actionType the action type, sent by the client
+	 *
+	 * @return bool true on success or false on failure
+	 */
+	#[Override]
+	public function messageList($store, $entryid, $action, $actionType) {
+		// Get the entryid of the inbox. Public stores don't have an inbox.
+		$inboxEntryid = false;
+
+		try {
+			$inbox = mapi_msgstore_getreceivefolder($store);
+			$inboxProps = mapi_getprops($inbox, [PR_ENTRYID]);
+			$inboxEntryid = bin2hex((string) $inboxProps[PR_ENTRYID]);
+			$this->_inboxEntryId = $inboxEntryid;
+		}
+		catch (MAPIException $e) {
+			// don't propagate this error to parent handlers, if store doesn't support it
+			if ($e->getCode() === MAPI_E_NO_SUPPORT) {
+				$e->setHandled();
+			}
+		}
+
+		// Only the Inbox can be rendered as conversations.
+		if (!$this->showAsConversations || $inboxEntryid === false || !$GLOBALS['entryid']->compareEntryIds($inboxEntryid, bin2hex((string) $entryid))) {
+			return parent::messageList($store, $entryid, $action, $actionType);
+		}
+
+		if (isset($action['restriction']['filter']) && $action['restriction']['filter'] !== false) {
+			return $this->prepareFilteredData($store, $action, $actionType);
+		}
+
+		return $this->conversationList($store, $entryid, $action, $actionType);
+	}
+
+	/**
+	 * Function will prepare filtered data in the list form by applying a restriction on the
+	 * conversation search folder. This is used when a filter (e.g. unread) is applied while
+	 * the conversation view is active.
+	 *
+	 * @param object $store      MAPI message store object
+	 * @param array  $action     the action data, sent by the client
+	 * @param string $actionType the action type, sent by the client
+	 *
+	 * @return bool true on success or false on failure
+	 */
+	public function prepareFilteredData($store, $action, $actionType) {
+		$searchFolder = $this->getConversationSearchFolder($this->currentActionData['store']);
+		if (!$searchFolder) {
+			error_log('grommunio-web: conversation view: no search folder found');
+
+			return [];
+		}
+
+		$entryid = mapi_getprops($searchFolder, [PR_ENTRYID])[PR_ENTRYID];
+		$this->parseRestriction($action);
+
+		// Sort
+		$this->parseSortOrder($action, null, true);
+
+		$limit = false;
+		if (isset($action['restriction']['limit'])) {
+			$limit = $action['restriction']['limit'];
+		}
+		else {
+			$limit = $GLOBALS['settings']->get('zarafa/v1/main/page_size', 50);
+		}
+
+		// Get the table and merge the arrays
+		$data = $GLOBALS["operations"]->getTable($store, $entryid, $this->properties, $this->sort, $this->start, $limit, $this->restriction);
+
+		$data = $this->filterPrivateItems($data);
+
+		// Allowing to hook in just before the data sent away to be sent to the client
+		$GLOBALS['PluginManager']->triggerHook('server.module.listmodule.list.after', [
+			'moduleObject' => &$this,
+			'store' => $store,
+			'entryid' => $entryid,
+			'action' => $action,
+			'data' => &$data,
+		]);
+
+		foreach ($data["item"] as $key => $itemData) {
+			$itemData['props']['folder_name'] = $GLOBALS['entryid']->compareEntryIds($itemData['parent_entryid'], $this->_inboxEntryId) ? 'inbox' : 'sent_items';
+			$data["item"][$key] = $itemData;
+		}
+
+		// unset will remove the value but will not regenerate array keys, so we need to
+		// do it here
+		$data["item"] = array_values($data["item"]);
+
+		$this->addActionData($actionType, $data);
+		$GLOBALS["bus"]->addData($this->getResponseData());
+
+		return true;
+	}
+
+	/**
+	 * Function which retrieves a list of messages grouped as conversations in a folder.
+	 *
+	 * @param object $store      MAPI message store object
+	 * @param string $entryid    entryid of the folder
+	 * @param array  $action     the action data, sent by the client
+	 * @param string $actionType the action type, sent by the client
+	 *
+	 * @return bool true on success or false on failure
+	 */
+	public function conversationList($store, $entryid, $action, $actionType) {
+		// Set to indicate this is not the search result, but a normal folder content
+		$this->searchFolderList = false;
+
+		if (!$store || !$entryid) {
+			return [];
+		}
+
+		// Restriction
+		$this->parseRestriction($action);
+
+		// Sort
+		$this->parseSortOrder($action, null, true);
+
+		// Open the state
+		$this->state = new State('conversation');
+		$this->state->open();
+
+		// Get the next CONVERSATION_BATCH_COUNT conversations from the folders
+		$count = CONVERSATION_BATCH_COUNT;
+		if ($actionType === 'updatelist' && $this->start === 0) {
+			// This will happen when the user updates the list because a new item was received
+			$count = $action['restriction']['limit'] ?? CONVERSATION_BATCH_COUNT;
+		}
+
+		$items = $this->getConversations($count);
+
+		$this->state->close();
+
+		$folderData = [];
+
+		// Obtain some statistics from the folder contents
+		if ($this->getInboxTotal()) {
+			$folderData["content_count"] = $this->getInboxTotal();
+			$folderData["content_unread"] = $this->getInboxTotalUnread();
+		}
+
+		// Get the number of 'real' inbox records that is sent back (i.e. without the
+		// conversation header records and without the sent items).
+		$itemCount = 0;
+		foreach ($items as $item) {
+			if ($item['props']['folder_name'] === 'inbox') {
+				++$itemCount;
+			}
+		}
+
+		$data = [
+			'folder' => $folderData,
+			'item' => $items,
+			'page' => [
+				'start' => 0,
+				'rowcount' => $itemCount,
+				'totalrowcount' => $folderData["content_count"] ?? $itemCount,
+			],
+		];
+
+		$data = $this->filterPrivateItems($data);
+
+		// Allowing to hook in just before the data sent away to be sent to the client
+		$GLOBALS['PluginManager']->triggerHook('server.module.listmodule.list.after', [
+			'moduleObject' => &$this,
+			'store' => $store,
+			'entryid' => $entryid,
+			'action' => $action,
+			'data' => &$data,
+		]);
+
+		$this->addActionData($actionType, $data);
+		$GLOBALS["bus"]->addData($this->getResponseData());
+
+		return true;
+	}
+
+	/**
+	 * Will iterate to retrieve the requested number of conversations (or whatever is left).
+	 *
+	 * @param int $count Number of conversations to fetch
+	 *
+	 * @return array Array of item objects grouped by conversation (together with headers)
+	 */
+	public function getConversations($count = CONVERSATION_BATCH_COUNT) {
+		$conversations = [];
+		$totalConversationCount = 0;
+		$requestedBatchFetched = false;
+
+		$infiniteScrollRequest = $this->currentActionData['actionType'] && $this->start > 0;
+		$start = $infiniteScrollRequest ? $this->state->read('firstUnusedInboxItemIndex') : 0;
+
+		// First batch will always contain max CONVERSATION_BATCH_COUNT conversations
+		$limit = min(CONVERSATION_BATCH_COUNT, $count);
+
+		$c = 0;
+
+		do {
+			$items = $this->getConversationItems($start);
+			if (count($items) === 0) {
+				break;
+			}
+			$items = $this->groupConversationItems($items, $limit, !($infiniteScrollRequest || $c > 0));
+
+			// addConversationHeaders returns the number of conversations that are contained
+			// in the $items after the headers have been added.
+			$batchConversationCount = $this->addConversationHeaders($items);
+
+			$requestedBatchFetched = $batchConversationCount === $limit;
+			$remainingInboxItems = $this->getInboxTotal() - $this->state->read('sentInboxItems');
+
+			$totalConversationCount += $batchConversationCount;
+
+			$conversations = array_merge($conversations, $items);
+
+			// Next iteration should always start where the previous one stopped
+			$start = $this->state->read('firstUnusedInboxItemIndex');
+			if ($start === -1) {
+				// We fetched all items
+				$remainingInboxItems = 0;
+			}
+
+			// Don't fetch more conversations than requested
+			$limit = min(CONVERSATION_BATCH_COUNT, $count - $totalConversationCount);
+
+			// If something goes wrong we don't want to hang here forever, so we'll use
+			// the counter to do no more than 30 iterations.
+			if ($c++ > 30) {
+				break;
+			}
+		}
+		while (!$requestedBatchFetched && $remainingInboxItems > 0 && $limit > 0);
+
+		return $conversations;
+	}
+
+	/**
+	 * Gets a batch of items from the conversation search folder, starting at the given index.
+	 *
+	 * @param int $start Index of the first item to fetch from the search folder
+	 *
+	 * @return array An array with items (array of props) sorted by client submit time
+	 */
+	public function getConversationItems($start) {
+		$searchFolder = $this->getConversationSearchFolder($this->currentActionData['store']);
+		if (!$searchFolder) {
+			error_log('grommunio-web: conversation view: no search folder found');
+
+			return [];
+		}
+
+		// Get the items from the search folder
+		$table = mapi_folder_getcontentstable($searchFolder, MAPI_DEFERRED_ERRORS);
+
+		$usedItemsAfterFirstUnusedInboxItems = $start > 0 ? $this->state->read('usedItemsAfterFirstUnusedInboxItems') : [];
+		$fetchCount = CONVERSATION_MAXFETCH + count((array) $usedItemsAfterFirstUnusedInboxItems);
+
+		// Get the items from the search folder
+		$rows = mapi_table_queryrows($table, $this->properties, $start, $fetchCount);
+
+		foreach ($rows as $i => $row) {
+			$itemData = Conversion::mapMAPI2XML($this->properties, $row);
+
+			// For ZARAFA type users the email_address properties are filled with the username.
+			// Here we will copy that property to the *_username property for consistency with
+			// the getMessageProps() function.
+			if (isset($itemData['props']["sent_representing_email_address"])) {
+				$itemData['props']["sent_representing_username"] = $itemData['props']["sent_representing_email_address"];
+			}
+			if (isset($itemData['props']["sender_email_address"])) {
+				$itemData['props']["sender_username"] = $itemData['props']["sender_email_address"];
+			}
+			if (isset($itemData['props']["received_by_email_address"])) {
+				$itemData['props']["received_by_username"] = $itemData['props']["received_by_email_address"];
+			}
+
+			// Make sure we have a normalized subject
+			if (!isset($itemData['props']['normalized_subject'])) {
+				$itemData['props']['normalized_subject'] = '';
+			}
+
+			$itemData['props']['folder_name'] = $GLOBALS['entryid']->compareEntryIds($itemData['parent_entryid'], $this->_inboxEntryId) ? 'inbox' : 'sent_items';
+			$itemData['props']['depth'] = 0;
+			$itemData['props']['conversation_count'] = 0;
+			$itemData['props']['tableindex'] = $i + $start;
+			$rows[$i] = $itemData;
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Group the given items by conversation (normalized subject + time heuristic) and
+	 * sort them by date. Conversations without any inbox item are dropped (we only render
+	 * conversations that contain at least one item in the inbox). The state is updated so
+	 * subsequent batches can continue where this one stopped.
+	 *
+	 * @param array $items          The items to group
+	 * @param int   $limit          Maximum number of conversations to keep
+	 * @param bool  $skipStoredItems True for the first batch, where no previously stored items should be skipped
+	 *
+	 * @return array The grouped (and sorted) items
+	 */
+	public function groupConversationItems($items, $limit, $skipStoredItems) {
+		$previousUsedItemsAfterFirstUnusedInboxItems = $skipStoredItems ? [] : (array) $this->state->read('usedItemsAfterFirstUnusedInboxItems');
+
+		$conversations = [];
+
+		// Group the items per conversation
+		foreach ($items as $item) {
+			// Don't use previously used items
+			if (!$skipStoredItems && count($previousUsedItemsAfterFirstUnusedInboxItems)) {
+				foreach ($previousUsedItemsAfterFirstUnusedInboxItems as $p) {
+					if ($GLOBALS['entryid']->compareEntryIds($p, $item['entryid'])) {
+						continue 2;
+					}
+				}
+			}
+
+			$sub = $item['props']['normalized_subject'];
+
+			// Don't group mails with empty subject and undelivered mails in a conversation.
+			if ($sub === '' || $item['props']['message_class'] === 'REPORT.IPM.Note.NDR') {
+				// Don't include sent items with empty subject.
+				if ($item['props']['folder_name'] === 'sent_items') {
+					continue;
+				}
+				// To avoid grouping of empty subject mails and undelivered mails and also treat
+				// them as a single conversation item, we need to add the item with a unique key.
+				$sub = $this->createUniqueConversationKey($item);
+			}
+
+			if (isset($conversations[$sub])) {
+				// Create a different conversation group if the time difference is more than
+				// MAX_TIME_DIFF even if the normalized subject is the same.
+				$timeDiff = abs($conversations[$sub]['date'] - $item['props']['client_submit_time']);
+				if ($timeDiff >= MAX_TIME_DIFF) {
+					$conversationKey = $this->findNearestConversationKey($conversations, $item);
+					$sub = $conversationKey ?: $this->createUniqueConversationKey($item);
+				}
+
+				$conversations[$sub]['items'][] = $item;
+				if (!isset($conversations[$sub]['date']) || $conversations[$sub]['date'] < $item['props']['client_submit_time']) {
+					$conversations[$sub]['date'] = $item['props']['client_submit_time'];
+				}
+			}
+			else {
+				$conversations[$sub] = [
+					'date' => $item['props']['client_submit_time'],
+					'items' => [$item],
+				];
+			}
+		}
+
+		// Remove conversations without inbox items
+		$removedConversationsCount = 0;
+		$removedItems = [];
+		$index = 0;
+		foreach ($conversations as $sub => $conversation) {
+			if ($index - $removedConversationsCount >= $limit) {
+				break;
+			}
+
+			$inboxItemFound = false;
+			foreach ($conversation['items'] as $item) {
+				if ($item['props']['folder_name'] === 'inbox') {
+					$inboxItemFound = true;
+					break;
+				}
+			}
+			if (!$inboxItemFound) {
+				if ($index < $limit + $removedConversationsCount) {
+					++$removedConversationsCount;
+
+					// Store the removed items, because we need them later
+					$removedItems = array_merge($removedItems, $conversation['items']);
+
+					// Remove this conversation
+					unset($conversations[$sub]);
+				}
+			}
+
+			++$index;
+		}
+
+		$conversationKeys = array_keys($conversations);
+
+		// Store the first item that will not be sent back
+		$firstUnusedInboxItem = null;
+		$firstUnusedInboxItemIndex = -1;
+		if (count($conversationKeys) > $limit) {
+			$item = $conversations[$conversationKeys[$limit]]['items'][0];
+			$firstUnusedInboxItem = $item['entryid'];
+			$firstUnusedInboxItemIndex = $item['props']['tableindex'];
+			for ($i = $limit; $i < count($conversationKeys); ++$i) {
+				foreach ($conversations[$conversationKeys[$i]]['items'] as $item) {
+					if ($item['props']['tableindex'] < $firstUnusedInboxItemIndex) {
+						$firstUnusedInboxItem = $item['entryid'];
+						$firstUnusedInboxItemIndex = $item['props']['tableindex'];
+					}
+				}
+			}
+		}
+
+		// Get the items that are part of sent conversations but that come after the first non-sent item
+		$usedItemsAfterFirstUnusedInboxItems = $previousUsedItemsAfterFirstUnusedInboxItems;
+		for ($i = 0; $i < min($limit, count($conversationKeys)); ++$i) {
+			// sort the items to make sure that sent items to yourself are shown in the correct order
+			usort($conversations[$conversationKeys[$i]]['items'], function ($a, $b) {
+				if ($a['props']['client_submit_time'] === $b['props']['client_submit_time']) {
+					return $a['props']['folder_name'] === 'inbox' ? -1 : 1;
+				}
+
+				return $b['props']['client_submit_time'] - $a['props']['client_submit_time'];
+			});
+
+			foreach ($conversations[$conversationKeys[$i]]['items'] as $item) {
+				if ($item['props']['tableindex'] > $firstUnusedInboxItemIndex) {
+					$usedItemsAfterFirstUnusedInboxItems[] = $item['entryid'];
+				}
+			}
+		}
+
+		// Add the removed items that come after the first non-sent item
+		foreach ($removedItems as $item) {
+			if ($item['props']['tableindex'] > $firstUnusedInboxItemIndex) {
+				$usedItemsAfterFirstUnusedInboxItems[] = $item['entryid'];
+			}
+		}
+
+		$sortedItems = [];
+		for ($counter = 0; $counter < min($limit, count($conversationKeys)); ++$counter) {
+			// Get the number of requested conversations. Add a maximum of CONVERSATION_MAXITEMS
+			// items. The rest can be loaded later.
+			$sortedItems = array_merge($sortedItems, array_slice($conversations[$conversationKeys[$counter]]['items'], 0, CONVERSATION_MAXITEMS));
+		}
+
+		// Get the number of inbox items in the conversations
+		$inboxCounter = $skipStoredItems ? 0 : $this->state->read('sentInboxItems');
+		foreach ($sortedItems as $item) {
+			if ($item['props']['folder_name'] === 'inbox') {
+				++$inboxCounter;
+			}
+		}
+
+		// Update the conversation batch number
+		$firstConversationGroupItemIndex = $sortedItems[0]['props']['tableindex'] ?? 0;
+		$previousUnusedItemIndex = $this->state->read('firstUnusedInboxItemIndex');
+
+		if ($previousUnusedItemIndex > 0 && $firstConversationGroupItemIndex >= $previousUnusedItemIndex) {
+			$batchNo = $this->state->read('batchNumber');
+			$this->state->write('batchNumber', $batchNo + 1, false);
+		}
+		else {
+			$this->state->write('batchNumber', 0, false);
+		}
+
+		// Store the data we need for the next batch in the state
+		$this->state->write('firstUnusedInboxItem', $firstUnusedInboxItem, false);
+		$this->state->write('firstUnusedInboxItemIndex', $firstUnusedInboxItemIndex, false);
+		$this->state->write('usedItemsAfterFirstUnusedInboxItems', $usedItemsAfterFirstUnusedInboxItems, false);
+		$this->state->write('sentInboxItems', $inboxCounter, false);
+		$this->state->flush();
+
+		return $sortedItems;
+	}
+
+	/**
+	 * Helper function which will create a unique conversation key to avoid the same-subject-key
+	 * issue, based on a hash value of the normalized subject and the entryid of the given item.
+	 *
+	 * @param array $item item for which a conversation key is needed
+	 *
+	 * @return string conversation key which will be used to group items in a conversation
+	 */
+	public function createUniqueConversationKey($item) {
+		$sub = $item['props']['normalized_subject'];
+		$prefix = md5((string) $sub) . '/';
+
+		// Append the entryid after the hash of the normalized subject. The entryid is unique so
+		// it has the first priority; 'tableindex' and a random number have lower priority.
+		if (isset($item['entryid'])) {
+			return $prefix . $item['entryid'];
+		}
+		if (isset($item['props']['tableindex'])) {
+			return $prefix . $item['props']['tableindex'];
+		}
+
+		return $prefix . random_int(0, mt_getrandmax());
+	}
+
+	/**
+	 * Helper function which will return the key of the conversation group that is nearest in time
+	 * to the given item, so that we can add the item to that group.
+	 *
+	 * @param array $conversations array which contains the conversation groups as key/value pairs
+	 * @param array $item          item for which a conversation key is needed
+	 *
+	 * @return bool|string conversation key to use to group the item, or false if none found
+	 */
+	public function findNearestConversationKey($conversations, $item) {
+		$sub = md5((string) $item['props']['normalized_subject']);
+		$time = $item['props']['client_submit_time'];
+		$minTimeDiff = MAX_TIME_DIFF;
+		$nearestConversationKey = false;
+
+		foreach ($conversations as $key => $value) {
+			$str = explode('/', $key);
+			$doesSubExist = count($str) === 2 && $str[0] === $sub;
+
+			if ($doesSubExist && abs($value['date'] - $time) < $minTimeDiff) {
+				$minTimeDiff = $value['date'];
+				$nearestConversationKey = $key;
+			}
+		}
+
+		return $nearestConversationKey;
+	}
+
+	/**
+	 * Adds fake records to the items that denote conversation headers. These fake records
+	 * will have the following properties:
+	 *  - 'entryid'            : a fake entryid based on the subject and position in the list
+	 *  - 'depth'             : 0 for conversation headers or single items, 1 for the rest
+	 *  - 'subject'           : the normalized subject
+	 *  - 'normalized_subject' : the normalized subject
+	 *  - 'conversation_count' : the number of items in the conversation
+	 *  - 'message_flags'      : message flags based on the items in the conversation
+	 *
+	 * The 'real' items will also get the depth property set: 0 for single items and 1 for items
+	 * that are part of a conversation.
+	 *
+	 * @param array $items The (grouped) items that will get headers added
+	 *
+	 * @return int The number of headers added (i.e. the number of conversations)
+	 */
+	public function addConversationHeaders(&$items) {
+		$conversationCount = 0;
+		$currentNormalizedSubject = false;
+		$currentConversationTimeStamp = false;
+		$currentHeaderIndex = -1;
+		$i = 0;
+
+		// We maintain a batch number to make the header entryid unique per batch.
+		$batchNo = $this->state->read('batchNumber');
+		$currentBatchSubjects = [];
+		while ($i < count($items)) {
+			// Don't add empty subject mails and undelivered mails to a conversation group,
+			// so the depth for those mails must remain '0'.
+			$isNonConversationGroupItem = $currentNormalizedSubject === '' || $items[$i]['props']['message_class'] === 'REPORT.IPM.Note.NDR';
+			$timeDiff = abs($currentConversationTimeStamp - $items[$i]['props']['client_submit_time']);
+			$isDifferentConversationGroup = ($items[$i]['props']['normalized_subject'] === $currentNormalizedSubject) && $timeDiff >= MAX_TIME_DIFF;
+
+			if ($items[$i]['props']['normalized_subject'] !== $currentNormalizedSubject || $isNonConversationGroupItem || $isDifferentConversationGroup) {
+				++$conversationCount;
+				$currentHeaderIndex = $i;
+				$currentNormalizedSubject = $items[$i]['props']['normalized_subject'];
+				$currentConversationTimeStamp = $items[$i]['props']['client_submit_time'];
+			}
+			elseif ($i === $currentHeaderIndex + 1) {
+				// We have a conversation, so add a header
+				$items[$currentHeaderIndex]['props']['depth'] = 1;
+				$items[$i]['props']['depth'] = 1;
+
+				if (isset($currentBatchSubjects[$currentNormalizedSubject])) {
+					$currentBatchSubjects[$currentNormalizedSubject] = ++$currentBatchSubjects[$currentNormalizedSubject];
+				}
+				else {
+					$currentBatchSubjects[$currentNormalizedSubject] = 0;
+				}
+
+				// Create a fake entryid for the headers based on the normalized subject. A batch
+				// number and repeated item number are added to make the entryid of groups with
+				// the same normalized subject in the same item batch unique.
+				$id = md5((string) $currentNormalizedSubject) . $batchNo . $currentBatchSubjects[$currentNormalizedSubject];
+
+				// Create a fake header object
+				$header = [
+					'entryid' => $id,
+					'props' => [
+						'depth' => 0,
+						'entryid' => $id,
+						'subject' => $currentNormalizedSubject,
+						'normalized_subject' => $currentNormalizedSubject,
+						'conversation_count' => 1,
+						'message_flags' => $items[$currentHeaderIndex]['props']['message_flags'],
+					],
+				];
+				array_splice($items, $currentHeaderIndex, 0, [$header]);
+				++$i;
+			}
+			else {
+				$items[$i]['props']['depth'] = 1;
+			}
+
+			// Update the header properties
+			if ($i > $currentHeaderIndex) {
+				++$items[$currentHeaderIndex]['props']['conversation_count'];
+				if (($items[$i]['props']['message_flags'] & 1) === 0) {
+					$items[$currentHeaderIndex]['props']['message_flags'] = 0;
+				}
+			}
+			++$i;
+		}
+
+		return $conversationCount;
+	}
+
+	/**
+	 * Returns the search folder that holds the items that are used to create the conversations in
+	 * the Inbox. If the folder does not exist yet, it will be created and this function will wait
+	 * (with a maximum of 20 seconds) until the folder is filled.
+	 *
+	 * @param resource $store The store in which the conversation search folder will be created
+	 *
+	 * @return bool|resource The search folder, or false on failure
+	 */
+	public function getConversationSearchFolder($store) {
+		$searchRoot = $this->getSearchFoldersRoot($store);
+
+		try {
+			// Return the search folder if it exists.
+			if ($this->doesSearchFolderExist($searchRoot)) {
+				return mapi_folder_createfolder($searchRoot, 'Conversation view search (grommunio Web)', null, OPEN_IF_EXISTS, FOLDER_SEARCH);
+			}
+
+			// Try to create a new search folder for the conversations if it doesn't exist.
+			$searchFolder = mapi_folder_createfolder($searchRoot, 'Conversation view search (grommunio Web)', null, 0, FOLDER_SEARCH);
+
+			// Find the entryids of the folders we want to search in. For now we use the inbox and
+			// sent items folders.
+			$msgstore_props = mapi_getprops($store, [PR_ENTRYID, PR_IPM_SENTMAIL_ENTRYID]);
+
+			$foldersToSearch = [
+				hex2bin((string) $this->_inboxEntryId),
+				$msgstore_props[PR_IPM_SENTMAIL_ENTRYID],
+			];
+			$res = [
+				RES_OR,
+				[
+					[
+						RES_PROPERTY,
+						[
+							RELOP => RELOP_EQ,
+							ULPROPTAG => PR_PARENT_ENTRYID,
+							VALUE => [PR_PARENT_ENTRYID => hex2bin((string) $this->_inboxEntryId)],
+						],
+					],
+					[
+						RES_PROPERTY,
+						[
+							RELOP => RELOP_EQ,
+							ULPROPTAG => PR_PARENT_ENTRYID,
+							VALUE => [PR_PARENT_ENTRYID => $msgstore_props[PR_IPM_SENTMAIL_ENTRYID]],
+						],
+					],
+				],
+			];
+
+			// SHALLOW_SEARCH means to search only in the specified folders and not in child folders
+			mapi_folder_setsearchcriteria($searchFolder, $res, $foldersToSearch, SHALLOW_SEARCH);
+
+			// Wait until we have some data, no point in returning before we have data. Stop waiting
+			// after 20 seconds.
+			$start = time();
+
+			// Sleep for 0.2 seconds initially, since it usually takes ~0.2 seconds to fill the
+			// search folder.
+			usleep(200000);
+
+			while (time() - $start < 20) {
+				$result = mapi_folder_getsearchcriteria($searchFolder);
+
+				// Stop looping if the search is finished
+				if (($result["searchstate"] & SEARCH_REBUILD) == 0) {
+					break; // Search is done
+				}
+
+				usleep(100000);
+			}
+		}
+		catch (MAPIException $e) {
+			error_log('grommunio-web: error creating search folder for conversation view: ' . $e->getMessage());
+
+			// don't propagate the event to higher level exception handlers
+			$e->setHandled();
+
+			return false;
+		}
+
+		return $searchFolder;
+	}
+
+	/**
+	 * Helper function which determines whether the conversation search folder already exists.
+	 *
+	 * @param resource $searchRoot FINDER_ROOT folder of the store in which we need to find the
+	 *                             conversation search folder
+	 *
+	 * @return bool true if the conversation search folder already exists, false otherwise
+	 */
+	public function doesSearchFolderExist($searchRoot) {
+		$searchRootFolderTable = mapi_folder_gethierarchytable($searchRoot);
+		$restriction = [
+			RES_AND,
+			[
+				[
+					RES_PROPERTY,
+					[
+						RELOP => RELOP_EQ,
+						ULPROPTAG => PR_FOLDER_TYPE,
+						VALUE => [PR_FOLDER_TYPE => FOLDER_SEARCH],
+					],
+				],
+				[
+					RES_CONTENT,
+					[
+						ULPROPTAG => PR_DISPLAY_NAME,
+						FUZZYLEVEL => FL_FULLSTRING,
+						VALUE => [PR_DISPLAY_NAME => 'Conversation view search (grommunio Web)'],
+					],
+				],
+			],
+		];
+
+		mapi_table_restrict($searchRootFolderTable, $restriction);
+		$folders = mapi_table_queryallrows($searchRootFolderTable, [PR_DISPLAY_NAME]);
+
+		// If we get data that means we already have the search folder.
+		return !empty($folders);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Implements the threaded/conversation view for email requested in grommunio/grommunio-web#81.

Mails are grouped into conversations across the **Inbox** and **Sent Items** folders, shown chronologically with expand/collapse. grommunio-web already shipped roughly half of this feature — the calling code (e.g. `ConversationManagers.js`, `SettingsConversationWidget.js`, the `isConversation*` record helpers, conversation-aware navigation in `MailRowSelectionModel`) was present, but the underlying engine had been stripped out, so nothing was wired up or functional.

Closes #81.

## How it works

- **Server** builds a MAPI search folder over Inbox + Sent Items, fetches items in batches (infinite-scroll friendly), groups them by normalized subject within a 3-month window, drops conversations that have no Inbox item, and injects synthetic "header" records (`depth = 0`, `conversation_count > 1`). Batch position is tracked across requests via `State('conversation')`.
- **Client** renders headers followed by their children; children (`depth > 0`) are hidden until the header is expanded. Expand/collapse toggles membership in the `ConversationManager` and re-filters the store. Header rows show aggregated read/unread state and an expand/collapse arrow; child rows are indented with thread connector lines.

## Changes

### Server
- `server/includes/modules/class.maillistmodule.php` — conversation grouping engine: `useConversationView`, `execute`/`messageList` overrides, `conversationList`, `prepareFilteredData`, `getConversations`, `getConversationItems`, `groupConversationItems`, `addConversationHeaders`, `createUniqueConversationKey`, `findNearestConversationKey`, `getConversationSearchFolder`, `doesSearchFolderExist`.

### Client
- `client/zarafa/mail/MailStore.js` — `conversationManager` + conversation methods (`containsConversations`, `isConversationOpened`, `manageOpenConversations`, `filterByConversations`, `toggleConversation`, `collapseAllConversation`, `expandConversation`, `getConversationItemsFromHeaderRecord`, `getHeaderRecordFromItem`, `getConversationCount`) and the conversation-aware `getStoreLength` branch.
- `client/zarafa/mail/MailRecord.js` — new record fields `depth`, `conversation_count`, `folder_name`.
- `client/zarafa/mail/ui/MailGrid.js` — conversation wiring and rendering (header expand/collapse, row CSS classes, thread lines, delete handling, header select guard), preserving grommunio's existing delayed preview-task logic.
- `client/zarafa/mail/settings/SettingsMailCategory.js` — register the `settingsconversationwidget`.
- `client/zarafa/settings/data/SettingsDefaultValues.js` — defaults for `enable_conversation_view` and `expand_single_conversation`.
- `client/resources/css/grommunio.css` — conversation row styling (indentation, expand/collapse arrows, thread connector lines, right-preview icon container).

## How to enable

Opt-in via **Settings → Mail → "Enable conversation view"**. The feature also requires live scroll, which is enabled by default. An optional "Collapse conversation when selecting a different email" setting is available.

## Testing

The PHP/MAPI server layer requires a running Gromox backend and so could not be executed in this environment; it was verified as follows:

- `php -l` clean on the changed PHP module.
- `tools/loadorder.php` build succeeds and confirms `ConversationManagers` is concatenated before `MailStore` (dependency resolved via `#dependsFile`).
- `eslint` on `client/zarafa` produces no new errors (only pre-existing environmental noise).

Manual end-to-end testing against a live Gromox/grommunio backend is recommended before merge.