### PR TITLE
Add attachment fallback for unsupported file drops in mail body

### DIFF
--- a/client/zarafa/common/form/TextArea.js
+++ b/client/zarafa/common/form/TextArea.js
@@ -49,20 +49,62 @@ Zarafa.common.form.TextArea = Ext.extend(Ext.form.TextArea, {
 	},
 
 	/**
-	 * Block file drops and show an error notification. The HTML
-	 * editor (TinyMCE) does this automatically, but the plain text
-	 * textarea has no such handling.
+	 * Block file drops on the plain-text body area. When the user drops a file
+	 * that cannot be embedded (which is every file in plain-text mode), offer
+	 * to add it as a message attachment instead.
 	 * @param {Ext.EventObject} e The drop event
 	 * @private
 	 */
 	onFileDrop: function(e)
 	{
 		var dt = e.browserEvent.dataTransfer;
-		if (dt && (Array.prototype.indexOf.call(dt.types, 'Files') >= 0 || dt.files.length > 0)) {
-			e.preventDefault();
-			container.getNotifier().notify('error', _('Attachment error'),
-				_('Dropped file type is not supported'));
+		if (!dt || (Array.prototype.indexOf.call(dt.types, 'Files') < 0 && dt.files.length === 0)) {
+			return;
 		}
+
+		e.preventDefault();
+
+		var files = dt.files;
+		if (!files || files.length === 0) {
+			return;
+		}
+
+		// Build a list of filenames for the confirmation message. Each name is
+		// HTML-encoded individually so that the '<br>' separators used to join
+		// them remain real line breaks instead of being escaped as literal text.
+		var names = [];
+		for (var i = 0, len = files.length; i < len; i++) {
+			names.push('\u2022 ' + Ext.util.Format.htmlEncode(files[i].name));
+		}
+
+		var self = this;
+		var filesSnapshot = files; // keep a reference before the event is recycled
+
+		Ext.MessageBox.confirm(
+			_('Add as attachment?'),
+			_('The following files cannot be embedded in the message body. Add them as attachments instead?') +
+				'<br><br>' + names.join('<br>'),
+			function(btn) {
+				if (btn !== 'yes') {
+					return;
+				}
+
+				// Walk up to the nearest panel that holds the mail record.
+				var panel = self.findParentByType('zarafa.mailcreatepanel') ||
+				            self.findParentByType('zarafa.recordcontentpanel');
+				if (!panel || !panel.record) {
+					return;
+				}
+
+				var store = panel.record.getSubStore('attachments');
+				// Run the same validation (max attachment count/size limits) that a
+				// direct drop on the Attachments field would perform, so the file is
+				// added/rejected/notified in exactly the same way either way.
+				if (store && store.canUploadFiles(filesSnapshot, { container: panel.getEl() })) {
+					store.uploadFiles(filesSnapshot);
+				}
+			}
+		);
 	},
 
 	/**

--- a/client/zarafa/common/ui/HtmlEditor.js
+++ b/client/zarafa/common/ui/HtmlEditor.js
@@ -45,6 +45,10 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 	constructor: function(config)
 	{
 		config = config || {};
+		// Captured here because inside the TinyMCE `setup` callback below, `this` is
+		// bound by TinyMCE itself (not the HtmlEditor instance), so a plain `this`
+		// reference there would not point to this component.
+		var self = this;
 		// Get supported font families
 		var fontFamilies = Zarafa.common.ui.htmleditor.Fonts.getFontFamilies();
 
@@ -108,6 +112,90 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 						if (iframe) {
 							iframe.setAttribute('title', _('Message body editor'));
 						}
+					});
+					// When a file is dropped into the editor body, TinyMCE embeds
+					// images inline but blocks all other file types with an error.
+					// Instead, offer to add non-embeddable files as attachments.
+					editor.on("drop", function(e) {
+						var dt = e.dataTransfer;
+						if (!dt) {
+							return;
+						}
+
+						// Collect the files that TinyMCE cannot embed (non-images).
+						// TinyMCE handles images itself and will have already called
+						// preventDefault() for them, so we check isDefaultPrevented().
+						if (e.isDefaultPrevented()) {
+							return;
+						}
+
+						var files = dt.files;
+						if (!files || files.length === 0) {
+							return;
+						}
+
+						// Image extensions that TinyMCE can embed inline.
+						var imageExts = (editor.options.get('images_file_types') || 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp').split(',');
+
+						var nonEmbeddable = [];
+						for (var i = 0; i < files.length; i++) {
+							var ext = (files[i].name.split('.').pop() || '').toLowerCase();
+							if (imageExts.indexOf(ext) < 0) {
+								nonEmbeddable.push(files[i]);
+							}
+						}
+
+						if (nonEmbeddable.length === 0) {
+							return;
+						}
+
+						// Prevent TinyMCE from showing its own "not supported" error.
+						e.preventDefault();
+
+						// HTML-encode each name individually so that the '<br>' separators
+						// used to join them remain real line breaks instead of being
+						// escaped as literal text.
+						var names = nonEmbeddable.map(function(f) { return '\u2022 ' + Ext.util.Format.htmlEncode(f.name); });
+
+						// Capture the record reference before the async callback.
+						var record = self.record;
+
+						// Zarafa.core.data.IPMAttachmentStore#uploadFiles() only treats its
+						// argument as "real" files (with size/type/contents) if it is a
+						// genuine FileList (it does a strict `instanceof FileList` check).
+						// A plain Array -- which is what our filtering above produces --
+						// fails that check and would silently be handled as a list of bare
+						// filenames, so the actual file contents would never be uploaded
+						// and the resulting attachment would be broken (0 bytes, no type).
+						// Rebuild a real FileList containing only the non-embeddable files
+						// so it is uploaded/attached exactly like a drop on the Attachments
+						// field would be.
+						var uploadFileList = nonEmbeddable;
+						if (typeof DataTransfer !== 'undefined') {
+							var fileListBuilder = new DataTransfer();
+							nonEmbeddable.forEach(function(f) {
+								fileListBuilder.items.add(f);
+							});
+							uploadFileList = fileListBuilder.files;
+						}
+
+						Ext.MessageBox.confirm(
+							_('Add as attachment?'),
+							_('The following files cannot be embedded in the message body. Add them as attachments instead?') +
+								'<br><br>' + names.join('<br>'),
+							function(btn) {
+								if (btn !== 'yes' || !record) {
+									return;
+								}
+
+								var store = record.getSubStore('attachments');
+								// Run the same validation (max attachment count/size limits)
+								// that a direct drop on the Attachments field would perform.
+								if (store && store.canUploadFiles(uploadFileList, { container: this.getEl() })) {
+									store.uploadFiles(uploadFileList);
+								}
+							}.createDelegate(self)
+						);
 					});
 				}
 			}

--- a/client/zarafa/common/ui/HtmlEditor.js
+++ b/client/zarafa/common/ui/HtmlEditor.js
@@ -122,9 +122,8 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 							return;
 						}
 
-						// Collect the files that TinyMCE cannot embed (non-images).
-						// TinyMCE handles images itself and will have already called
-						// preventDefault() for them, so we check isDefaultPrevented().
+						// Defensive: if another plugin already handled this drop and
+						// prevented the default, leave it alone.
 						if (e.isDefaultPrevented()) {
 							return;
 						}
@@ -138,10 +137,13 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 						var imageExts = (editor.options.get('images_file_types') || 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp').split(',');
 
 						var nonEmbeddable = [];
+						var hasEmbeddable = false;
 						for (var i = 0; i < files.length; i++) {
 							var ext = (files[i].name.split('.').pop() || '').toLowerCase();
 							if (imageExts.indexOf(ext) < 0) {
 								nonEmbeddable.push(files[i]);
+							} else {
+								hasEmbeddable = true;
 							}
 						}
 
@@ -149,8 +151,16 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 							return;
 						}
 
-						// Prevent TinyMCE from showing its own "not supported" error.
-						e.preventDefault();
+						// Suppress TinyMCE's own "Dropped file type is not supported" error
+						// only when there is nothing for TinyMCE to embed. When the same drop
+						// also contains images, TinyMCE's paste handler (which runs after this
+						// one) embeds them and calls preventDefault() itself -- which also
+						// suppresses that error. Calling preventDefault() here in that case
+						// would make TinyMCE's handler bail on isDefaultPrevented() and the
+						// images would be silently discarded.
+						if (!hasEmbeddable) {
+							e.preventDefault();
+						}
 
 						// HTML-encode each name individually so that the '<br>' separators
 						// used to join them remain real line breaks instead of being


### PR DESCRIPTION
Problem
Dropping a non-embeddable file (e.g. .pdf, .txt, .docx) directly into the mail compose body previously failed silently or with an unhelpful error:

- HTML mode: TinyMCE showed "Dropped file type is not supported" and discarded the file.
- Plain-text mode: the same generic error was shown via a notification.

Only dropping onto the narrow Attachments field (next to the "Attachments" button) worked, which is a small, easy-to-miss target. Images already worked correctly since TinyMCE embeds them inline.


Fix
Both the plain-text (TextArea.js) and HTML (HtmlEditor.js) editors now intercept drops of non-embeddable files before the error is shown, and instead prompt the user:

> Add as attachment?
The following files cannot be embedded in the message body. Add them as attachments instead?
• filename.pdf

On confirmation, the file(s) are uploaded via the same IPMAttachmentStore.canUploadFiles() / uploadFiles() API used by the dedicated Attachments field — so they go through the same size-cap / attachment-count validation and end up attached identically, regardless of which drop target was used.