### PR TITLE
Fix meeting-resource auto-accept and location auto-fill for room/equipment attendees

### DIFF
--- a/client/zarafa/calendar/Actions.js
+++ b/client/zarafa/calendar/Actions.js
@@ -287,7 +287,19 @@ Zarafa.calendar.Actions = {
 				records.applyData(copy);
 			},
 			convert: function(user, field) {
-				return user.convertToRecipient(field ? field.defaultRecipientType : config.defaultRecipientType);
+				// Rooms/equipment must always be treated as resources (MAPI_BCC),
+				// regardless of which field (Required/Optional/Resource) they were
+				// added through, so that server-side auto-accept works correctly.
+				// display_type_ex can carry additional flag bits (e.g.
+				// DTE_FLAG_ACL_CAPABLE) alongside the base type, so the flags must
+				// be stripped via DTE_LOCAL() before comparing against DT_ROOM/DT_EQUIPMENT.
+				var localDisplayTypeEx = Zarafa.core.mapi.DisplayTypeEx.DTE_LOCAL(user.get('display_type_ex'));
+				var isResource = localDisplayTypeEx === Zarafa.core.mapi.DisplayTypeEx.DT_ROOM ||
+				                  localDisplayTypeEx === Zarafa.core.mapi.DisplayTypeEx.DT_EQUIPMENT;
+				var recipientType = isResource ?
+					Zarafa.core.mapi.RecipientType.MAPI_BCC :
+					(field ? field.defaultRecipientType : config.defaultRecipientType);
+				return user.convertToRecipient(recipientType);
 			},
 			store: store,
 			selectionCfg: [{

--- a/client/zarafa/calendar/dialogs/AppointmentTab.js
+++ b/client/zarafa/calendar/dialogs/AppointmentTab.js
@@ -882,7 +882,10 @@ Zarafa.calendar.dialogs.AppointmentTab = Ext.extend(Ext.form.FormPanel, {
 				var isResouceChanged = false;
 
 				for(var i = 0; i < changedRecipients.length; i++) {
-					if(changedRecipients[i].get('display_type_ex') === Zarafa.core.mapi.DisplayTypeEx.DT_ROOM) {
+					// display_type_ex can carry additional flag bits (e.g.
+					// DTE_FLAG_ACL_CAPABLE) alongside the base type, so the flags
+					// must be stripped via DTE_LOCAL() before comparing against DT_ROOM.
+					if(Zarafa.core.mapi.DisplayTypeEx.DTE_LOCAL(changedRecipients[i].get('display_type_ex')) === Zarafa.core.mapi.DisplayTypeEx.DT_ROOM) {
 						isResouceChanged = true;
 						break;
 					}
@@ -957,7 +960,10 @@ Zarafa.calendar.dialogs.AppointmentTab = Ext.extend(Ext.form.FormPanel, {
 
 		// Create location suggestion string using room resources of the recipient store
 		recipientStore.each(function(recipient) {
-			if (recipient.get('display_type_ex') === Zarafa.core.mapi.DisplayTypeEx.DT_ROOM){
+			// display_type_ex can carry additional flag bits (e.g. DTE_FLAG_ACL_CAPABLE)
+			// alongside the base type, so the flags must be stripped via DTE_LOCAL()
+			// before comparing against DT_ROOM.
+			if (Zarafa.core.mapi.DisplayTypeEx.DTE_LOCAL(recipient.get('display_type_ex')) === Zarafa.core.mapi.DisplayTypeEx.DT_ROOM){
 				var name = recipient.get('display_name');
 
 				if (!Ext.isEmpty(name)) {


### PR DESCRIPTION
Problem

1. Auto-accept broken for resources added as regular attendees. When adding a room or equipment resource to a meeting via the "Required" or "Optional" field in the attendee-selection dialog, it was treated as a normal attendee (recipient_type = MAPI_TO/MAPI_CC) instead of a resource (MAPI_BCC), so server-side auto-accept never kicked in unless the resource was added through the dedicated "Resource" field specifically.
2. Meeting location not auto-filled from room resources. grommunio Web already had logic to auto-populate the meeting location field from any room resources on the attendee list, but it silently never triggered for real resources.

Root cause
Both bugs stem from the same underlying issue: resource address-book entries carry display_type_ex values with additional flag bits set (e.g. DTE_FLAG_ACL_CAPABLE) alongside the base type (DT_ROOM / DT_EQUIPMENT). Existing code compared display_type_ex with strict === against the raw DT_ROOM/DT_EQUIPMENT constants, which never matches once those flag bits are present — this affected both the attendee-conversion logic and the (already-existing but dead) location-suggestion logic.

fixes #91 