### PR TITLE
fix: dragging a folder onto its own tier renames it instead of doing nothing

### DIFF
--- a/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
+++ b/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
@@ -37,12 +37,6 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 	 */
 	onBeforeNodeDrop: function(dropEvent)
 	{
-		// Multiple DropZones might have been installed on the Tree,
-		// check if this event is coming from this class.
-		if (dropEvent.source !== this) {
-			return;
-		}
-
 		var dropNode = dropEvent.dropNode;
 
 		if (Ext.isDefined(dropNode)) {

--- a/client/zarafa/hierarchy/ui/HierarchyTreePanel.js
+++ b/client/zarafa/hierarchy/ui/HierarchyTreePanel.js
@@ -386,6 +386,16 @@ Zarafa.hierarchy.ui.HierarchyTreePanel = Ext.extend(Zarafa.hierarchy.ui.Tree, {
 			var hasAccess = targetFolder.get('access') & Zarafa.core.mapi.Access.ACCESS_CREATE_HIERARCHY;
 			var hasCtrlKeyPressed = dropEvent.rawEvent.ctrlKey;
 
+			// Guard: dropping a folder onto the tier it already lives in must be a no-op.
+			// Compare by MAPI entryid (not tree-node identity) so this also holds for
+			// shared/favorites stores where nodes may be distinct objects. Only guard the
+			// move path; a Ctrl-copy into the same parent is a legitimate duplicate.
+			if (!hasCtrlKeyPressed &&
+				Zarafa.core.EntryId.compareEntryIds(sourceFolder.get('parent_entryid'), targetFolder.get('entryid')) &&
+				Zarafa.core.EntryId.compareEntryIds(sourceFolder.get('store_entryid'), targetFolder.get('store_entryid'))) {
+				return false;
+			}
+
 			var msg;
 			if (!hasAccess) {
 				msg = hasCtrlKeyPressed ? _("You have insufficient privileges to copy this folder. Ask the folder owner to grant you permissions or contact your system administrator.") :


### PR DESCRIPTION
### Summary
Dragging a folder and dropping it onto the tier it already lives in (e.g. a sub-folder of Inbox dropped next to or onto Inbox, without actually placing it into a different folder) renames the folder to Name (2) instead of doing nothing.

### **Root cause**
The only guard against same-parent drops, HierarchyFolderDropZone.onBeforeNodeDrop, starts with:

```
if (dropEvent.source !== this) {
    return;
}
```
`dropEvent.source` is set to the drag source (the tree's DragZone) by the base ExtJS `processDrop`, passed in from `DragDropMgr.onDragDrop` via` target.notifyDrop(this, e, this.dragData)`. It is never the DropZone (`this`), so this condition is always true, the handler always returns early, and the same-parent cancellation below it is dead code. (The guard is also unnecessary — item drops fire `beforeitemdrop`, not `beforenodedrop`, so this handler only ever runs for folder drops.)

Because the drop is never cancelled, `onFolderDrop` calls `moveTo(targetFolder)` even when the target is the current parent. The backend then does a `FOLDER_MOVE` into the same parent, which throws `MAPI_E_COLLISION `(a folder with that name already exists there); the collision handler generates a de-duplicated name via `checkFolderNameConflict ` and re-moves with Name (2) — the visible "rename".

### **Fix**
Frontend only; the backend collision handler is correct for genuine cross-store name clashes and is left untouched.

1. Remove the dead `source !== this` guard in `HierarchyFolderDropZone.onBeforeNodeDrop`, restoring the intended same-parent cancellation (node-identity `dropNode.parentNode === targetNode`).
2. Add an entryid-based backstop in` HierarchyTreePanel.onFolderDrop`: bail out before `moveTo` when the source's `parent_entryid/store_entryid` already match the target folder, using `Zarafa.core.EntryId.compareEntryIds` rather than tree-node identity so it also holds in shared/favorites stores. The Ctrl-copy path is deliberately excluded, since copying into the same parent to create a duplicate is legitimate. 

fix #87 