### PR TITLE
feat(rules): add "Run rules now" to apply rules to existing messages

### DIFF
--- a/client/zarafa/common/rules/ui/RulesGrid.js
+++ b/client/zarafa/common/rules/ui/RulesGrid.js
@@ -96,6 +96,21 @@ Zarafa.common.rules.ui.RulesGrid = Ext.extend(Zarafa.common.ui.grid.GridPanel, {
 			ref: '../downButton',
 			handler: this.onRuleSequenceDown,
 			scope: this
+		}, '->', {
+			xtype: 'button',
+			text: _('Run selected'),
+			tooltip: _('Run the selected rule on the messages in a folder'),
+			disabled: true,
+			ref: '../runButton',
+			handler: this.onRuleRunSelected,
+			scope: this
+		}, {
+			xtype: 'button',
+			text: _('Run all'),
+			tooltip: _('Run all active rules on the messages in a folder'),
+			ref: '../runAllButton',
+			handler: this.onRuleRunAll,
+			scope: this
 		},
 			container.populateInsertionPoint('settings.rules.action.last')
 		];
@@ -260,6 +275,7 @@ Zarafa.common.rules.ui.RulesGrid = Ext.extend(Zarafa.common.ui.grid.GridPanel, {
 
 		this.removeButton.setDisabled(noSelection);
 		this.editButton.setDisabled(noSelection);
+		this.runButton.setDisabled(noSelection);
 
 		this.upButton.setDisabled(!selectionModel.hasPrevious());
 		this.downButton.setDisabled(!selectionModel.hasNext());
@@ -411,6 +427,102 @@ Zarafa.common.rules.ui.RulesGrid = Ext.extend(Zarafa.common.ui.grid.GridPanel, {
 		var sm = this.getSelectionModel();
 		this.upButton.setDisabled(!sm.hasPrevious());
 		this.downButton.setDisabled(!sm.hasNext());
+	},
+
+	/**
+	 * Handler for the 'Run selected' button. Runs only the currently selected
+	 * rule on the messages already present in a user-chosen folder.
+	 * @private
+	 */
+	onRuleRunSelected: function()
+	{
+		var ruleRecord = this.getSelectionModel().getSelected();
+		if (!ruleRecord) {
+			container.getNotifier().notify('error.rules', _('Error'), _('Please select a rule.'));
+			return;
+		}
+
+		this.runRules([ ruleRecord.get('rule_id') ]);
+	},
+
+	/**
+	 * Handler for the 'Run all' button. Runs all active rules on the messages
+	 * already present in a user-chosen folder.
+	 * @private
+	 */
+	onRuleRunAll: function()
+	{
+		// An empty rule list instructs the server to run all enabled rules.
+		this.runRules([]);
+	},
+
+	/**
+	 * Opens a folder selection dialog and, once a folder is chosen, requests
+	 * the server to apply the given rules to the messages in that folder.
+	 * @param {Array} ruleIds The rule_id values to run, or an empty array to
+	 * run all active rules.
+	 * @private
+	 */
+	runRules: function(ruleIds)
+	{
+		Zarafa.hierarchy.Actions.openFolderSelectionContent({
+			hideTodoList: true,
+			callback: this.onRunFolderSelected.createDelegate(this, [ ruleIds ], true),
+			scope: this,
+			modal: true
+		});
+	},
+
+	/**
+	 * Callback for the folder selection dialog. Dispatches the 'apply' request
+	 * to the rules module for the selected folder.
+	 * @param {Zarafa.hierarchy.data.MAPIFolderRecord} folder The chosen folder
+	 * @param {Array} ruleIds The rule_id values to run (empty for all rules)
+	 * @private
+	 */
+	onRunFolderSelected: function(folder, ruleIds)
+	{
+		if (!folder) {
+			return;
+		}
+
+		container.getRequest().singleRequest('rulesmodule', 'apply', {
+			store_entryid: this.getStore().storeEntryId,
+			folder_entryid: folder.get('entryid'),
+			rule_ids: ruleIds
+		}, new Zarafa.core.data.AbstractResponseHandler({
+			doApply: this.onRulesApplied.createDelegate(this),
+			doError: this.onRulesApplyError.createDelegate(this)
+		}));
+	},
+
+	/**
+	 * Success handler for the 'apply' request. Notifies the user with a short
+	 * summary of what the rule run did.
+	 * @param {Object} response The response data containing the run counts
+	 * @private
+	 */
+	onRulesApplied: function(response)
+	{
+		var affected = (response.moved || 0) + (response.copied || 0) +
+			(response.deleted || 0) + (response.marked_read || 0) + (response.tagged || 0);
+
+		var msg = String.format(ngettext('{0} message was affected.', '{0} messages were affected.', affected), affected);
+		if (response.skipped_actions > 0) {
+			msg += ' ' + String.format(ngettext('{0} action was skipped.', '{0} actions were skipped.', response.skipped_actions), response.skipped_actions);
+		}
+
+		container.getNotifier().notify('info.rules', _('Rules applied'), msg);
+	},
+
+	/**
+	 * Error handler for the 'apply' request.
+	 * @param {Object} response The error response
+	 * @private
+	 */
+	onRulesApplyError: function(response)
+	{
+		container.getNotifier().notify('error.rules', _('Error'), _('Could not apply rules.'));
 	}
 });
 

--- a/server/includes/modules/class.rulesmodule.php
+++ b/server/includes/modules/class.rulesmodule.php
@@ -92,6 +92,21 @@ class RulesModule extends Module {
 						}
 						break;
 
+					case 'apply':
+						// Run existing rules over the messages already present
+						// in a folder ("Run rules now"). The client sends the
+						// target folder and, optionally, the subset of rules to
+						// run (by PR_RULE_ID); when no subset is given all
+						// enabled rules are executed.
+						$folderEntryid = !empty($action['folder_entryid']) ? hex2bin((string) $action['folder_entryid']) : false;
+						$ruleIds = isset($action['rule_ids']) && is_array($action['rule_ids']) ? $action['rule_ids'] : [];
+
+						$result = $this->applyRules($store, $folderEntryid, $ruleIds);
+
+						$this->addActionData('apply', $result);
+						$GLOBALS['bus']->addData($this->getResponseData());
+						break;
+
 					default:
 						$this->handleUnknownActionType($actionType);
 				}
@@ -264,6 +279,243 @@ class RulesModule extends Module {
 	}
 
 	/**
+	 * Read the rules which should be executed by {@link applyRules()}, in
+	 * sequence order. Unlike {@link getRules()} this returns the native MAPI
+	 * property structures (PR_RULE_CONDITION / PR_RULE_ACTIONS) so they can be
+	 * handed directly to mapi_table_restrict() and the message operations,
+	 * rather than the XML representation meant for the client.
+	 *
+	 * Only enabled rules are returned. Rules which only apply while the user is
+	 * out-of-office (ST_ONLY_WHEN_OOF) are skipped, as are rules without a
+	 * usable condition or action.
+	 *
+	 * @param resource $store   The store containing the rules
+	 * @param array    $ruleIds Optional subset of PR_RULE_ID values to run;
+	 *                          when empty all enabled rules are returned
+	 *
+	 * @return array list of rule rows (associative MAPI property arrays)
+	 */
+	public function getRulesForExecution($store, $ruleIds = []) {
+		$rulesTable = mapi_folder_getrulestable($this->getRulesFolder($store));
+		mapi_table_restrict($rulesTable, $this->getRestriction(), TBL_BATCH);
+		mapi_table_sort($rulesTable, [PR_RULE_SEQUENCE => TABLE_SORT_ASCEND], TBL_BATCH);
+
+		// Read with the same full property set as getRules(); this is known to
+		// return PR_RULE_STATE / PR_RULE_CONDITION / PR_RULE_ACTIONS reliably.
+		// The raw row already holds the native MAPI structures keyed by
+		// property tag, which is exactly what we need for execution.
+		$rows = mapi_table_queryallrows($rulesTable, $this->properties);
+
+		$rules = [];
+		foreach ($rows as $row) {
+			$state = $row[PR_RULE_STATE] ?? 0;
+
+			// When a subset was requested, skip rules which are not part of it.
+			if (!empty($ruleIds) && !in_array($row[PR_RULE_ID] ?? null, $ruleIds)) {
+				continue;
+			}
+
+			// Only run rules which are enabled and not restricted to
+			// out-of-office.
+			if (!($state & ST_ENABLED) || ($state & ST_ONLY_WHEN_OOF)) {
+				continue;
+			}
+
+			// A rule without a condition or without actions cannot be applied.
+			if (empty($row[PR_RULE_CONDITION]) || empty($row[PR_RULE_ACTIONS])) {
+				continue;
+			}
+
+			$rules[] = $row;
+		}
+
+		return $rules;
+	}
+
+	/**
+	 * Rule conditions read from PR_RULE_CONDITION are often wrapped in
+	 * RES_COMMENT nodes which carry address-book annotation properties used by
+	 * the rule editor (e.g. the resolved sender for a "from X" rule). gromox
+	 * rejects those RES_COMMENT nodes when the condition is applied as a
+	 * restriction to a contents table (it fails with MAPI error 0x4B9), so we
+	 * recursively replace every RES_COMMENT with the actual restriction it
+	 * wraps before handing the condition to mapi_table_restrict().
+	 *
+	 * @param mixed $restriction A MAPI restriction array
+	 *
+	 * @return mixed the restriction with all RES_COMMENT wrappers removed
+	 */
+	public function stripCommentRestriction($restriction) {
+		if (!is_array($restriction) || count($restriction) < 2) {
+			return $restriction;
+		}
+
+		$type = $restriction[0];
+		$data = $restriction[1];
+
+		switch ($type) {
+			case RES_COMMENT:
+				// Replace the comment with the restriction it wraps.
+				$inner = $data[RESTRICTION] ?? null;
+
+				return $inner === null ? $restriction : $this->stripCommentRestriction($inner);
+
+			case RES_AND:
+			case RES_OR:
+			case RES_NOT:
+				// These hold a plain array of sub-restrictions.
+				$subs = [];
+				foreach ($data as $sub) {
+					$subs[] = $this->stripCommentRestriction($sub);
+				}
+
+				return [$type, $subs];
+
+			default:
+				return $restriction;
+		}
+	}
+
+	/**
+	 * Apply existing rules to the messages already present in a folder
+	 * ("Run rules now"). For every rule the folder's contents table is
+	 * restricted by the rule's PR_RULE_CONDITION (evaluated by the store, so
+	 * no restriction engine is needed here) and the resulting messages are
+	 * processed according to the rule's PR_RULE_ACTIONS.
+	 *
+	 * Supported actions are OP_MOVE, OP_COPY, OP_DELETE, OP_MARK_AS_READ and
+	 * OP_TAG. Other action types (forward, reply, bounce, deferred, delegate,
+	 * out-of-office reply) are counted as skipped and not executed.
+	 *
+	 * @param resource     $store          The store on which the rules run
+	 * @param string|false $folderEntryid  Entryid of the folder to run against;
+	 *                                     defaults to the receive folder (Inbox)
+	 * @param array        $ruleIds        Optional subset of PR_RULE_ID values
+	 *
+	 * @return array summary counts of the executed run
+	 */
+	public function applyRules($store, $folderEntryid = false, $ruleIds = []) {
+		$result = [
+			'success' => true,
+			'rules_run' => 0,
+			'matched' => 0,
+			'moved' => 0,
+			'copied' => 0,
+			'deleted' => 0,
+			'marked_read' => 0,
+			'tagged' => 0,
+			'skipped_actions' => 0,
+		];
+
+		// Default to the receive folder (Inbox) when no folder is provided.
+		if (empty($folderEntryid)) {
+			$folder = $this->getRulesFolder($store);
+			$folderProps = mapi_getprops($folder, [PR_ENTRYID]);
+			$folderEntryid = $folderProps[PR_ENTRYID];
+		}
+
+		$storeProps = mapi_getprops($store, [PR_IPM_WASTEBASKET_ENTRYID]);
+		$wastebasketEntryid = $storeProps[PR_IPM_WASTEBASKET_ENTRYID] ?? false;
+
+		$rules = $this->getRulesForExecution($store, $ruleIds);
+
+		// Keep the folder object in a variable for the whole run: the contents
+		// table is a child of this folder, and if the folder were freed (e.g.
+		// by opening it inline) its handle would be invalidated and the table
+		// operations would fail with MAPI error 0x4B9.
+		$sourceFolder = mapi_msgstore_openentry($store, $folderEntryid);
+
+		foreach ($rules as $rule) {
+			// Find the messages in the folder which match the rule's condition.
+			// The store evaluates the PR_RULE_CONDITION restriction for us.
+			try {
+				$contentsTable = mapi_folder_getcontentstable($sourceFolder, MAPI_DEFERRED_ERRORS);
+				$condition = $this->stripCommentRestriction($rule[PR_RULE_CONDITION]);
+				mapi_table_restrict($contentsTable, $condition, TBL_BATCH);
+				$matchRows = mapi_table_queryallrows($contentsTable, [PR_ENTRYID]);
+			}
+			catch (MAPIException $e) {
+				// A condition we cannot evaluate (e.g. a parse error) simply
+				// matches nothing; log it and move on to the next rule.
+				error_log(sprintf('applyRules: could not evaluate rule condition (0x%08X): %s', $e->getCode(), $e->getMessage()));
+
+				continue;
+			}
+
+			$entryids = [];
+			foreach ($matchRows as $matchRow) {
+				$entryids[] = $matchRow[PR_ENTRYID];
+			}
+
+			++$result['rules_run'];
+
+			if (empty($entryids)) {
+				continue;
+			}
+
+			$result['matched'] += count($entryids);
+
+			foreach ($rule[PR_RULE_ACTIONS] as $action) {
+				switch ($action['action']) {
+					case OP_MOVE:
+					case OP_COPY:
+						$destStore = $store;
+						if (!empty($action['storeentryid'])) {
+							$destStore = $GLOBALS['mapisession']->openMessageStore($action['storeentryid']);
+						}
+						$moveMessages = $action['action'] === OP_MOVE;
+						if ($GLOBALS['operations']->copyMessages($store, $folderEntryid, $destStore, $action['folderentryid'], $entryids, false, $moveMessages)) {
+							$result[$moveMessages ? 'moved' : 'copied'] += count($entryids);
+						}
+						break;
+
+					case OP_DELETE:
+						// Model a delete as a (soft) move to the wastebasket,
+						// consistent with how the client authors delete rules.
+						if ($wastebasketEntryid && $GLOBALS['operations']->copyMessages($store, $folderEntryid, $store, $wastebasketEntryid, $entryids, false, true)) {
+							$result['deleted'] += count($entryids);
+						}
+						break;
+
+					case OP_MARK_AS_READ:
+						foreach ($entryids as $entryid) {
+							$message = mapi_msgstore_openentry($store, $entryid);
+							if ($message) {
+								mapi_message_setreadflag($message, SUPPRESS_RECEIPT);
+								++$result['marked_read'];
+							}
+						}
+						break;
+
+					case OP_TAG:
+						if (isset($action['proptag'], $action['value'])) {
+							foreach ($entryids as $entryid) {
+								$message = mapi_msgstore_openentry($store, $entryid);
+								if ($message) {
+									mapi_setprops($message, [$action['proptag'] => $action['value']]);
+									mapi_savechanges($message);
+									++$result['tagged'];
+								}
+							}
+						}
+						break;
+
+					default:
+						// forward / reply / bounce / defer / delegate / oof
+						++$result['skipped_actions'];
+						break;
+				}
+			}
+		}
+
+		// Notify the client so the affected folder's message list refreshes.
+		$notifyProps = mapi_getprops($sourceFolder, [PR_ENTRYID, PR_STORE_ENTRYID]);
+		$GLOBALS['bus']->notify(bin2hex((string) $notifyProps[PR_ENTRYID]), OBJECT_SAVE, $notifyProps);
+
+		return $result;
+	}
+
+	/**
 	 * Function will delete (outlook) client rules. Outlook maintains client rules
 	 * in associated table of inbox, When we create/delete/update rule from webapp
 	 * it won't match with outlook's client rules, so it will confuse outlook and
@@ -329,6 +581,10 @@ class RulesModule extends Module {
 
 				case 'save':
 					$e->setDisplayMessage(_('Could not save rules.'));
+					break;
+
+				case 'apply':
+					$e->setDisplayMessage(_('Could not apply rules.'));
 					break;
 			}
 		}


### PR DESCRIPTION
Adds the ability to run existing mail rules over messages already in a folder, implementing issue #86 . Previously rules were only  evaluated by the server at delivery time.

Two buttons are added to the Mail Filters settings grid: "Run all" runs every active rule in sequence, "Run selected" runs only the highlighted rule. Both open a folder picker (default Inbox) and report a summary of how many messages were affected.

Server side (class.rulesmodule.php) adds an "apply" action:
- getRulesForExecution() reads enabled, non-OOF rules in sequence order  with their native PR_RULE_CONDITION / PR_RULE_ACTIONS.
- applyRules() restricts the folder's contents table by each rule's condition (the store evaluates it) and runs the matching messages
  through the rule's actions: OP_MOVE, OP_COPY, OP_DELETE (soft-delete to wastebasket), OP_MARK_AS_READ and OP_TAG. Forward/reply/bounce/deferred/delegate/OOF actions are counted as skipped and reported.
- stripCommentRestriction() recursively unwraps RES_COMMENT nodes, which gromox rejects when a rule condition is used as a table restriction.
- The source folder is held in a variable for the whole run to avoid the contents-table handle being invalidated (MAPI error 0x4B9).




