### PR TITLE
feat: highlight follow-up flagged mails in the message list

### DIFF
--- a/client/resources/css/darkmode.css
+++ b/client/resources/css/darkmode.css
@@ -700,6 +700,19 @@ body.dark-mode #zarafa-mainpanel .x-grid3-row.x-grid3-row-selected {
 	background-color: var(--dm-selected) !important;
 }
 
+/* Flagged (follow-up) items - highlight the whole row like Outlook.
+   The tint persists on hover and when the row is selected (a touch deeper),
+   so a flagged mail stays highlighted after you click it. */
+body.dark-mode #zarafa-mainpanel .x-grid3-row.k-flagged {
+	background-color: #40382a !important;
+}
+body.dark-mode #zarafa-mainpanel .x-grid3-row.k-flagged.x-grid3-row-over {
+	background-color: #4a4130 !important;
+}
+body.dark-mode #zarafa-mainpanel .x-grid3-row.k-flagged.x-grid3-row-selected {
+	background-color: #574a33 !important;
+}
+
 /*=============================================================================
   Message Preview
 =============================================================================*/

--- a/client/resources/css/grommunio.css
+++ b/client/resources/css/grommunio.css
@@ -1405,6 +1405,17 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   .k-unreadborders .x-grid3-row.x-grid3-row-collapsed.mail_unread > table, .k-unreadborders .x-grid3-row.x-grid3-row-expanded.mail_unread > table {
     border-left: 4px solid #1e88e5 !important; }
 
+/* Flagged (follow-up) items - highlight the whole row like Outlook.
+   The tint persists on hover and when the row is selected (a touch deeper),
+   so a flagged mail stays highlighted after you click it; selection is still
+   indicated by the blue left border. */
+.x-grid3-row.k-flagged {
+  background-color: #fff6e5 !important; }
+.x-grid3-row.k-flagged.x-grid3-row-over {
+  background-color: #fbedd0 !important; }
+.x-grid3-row.k-flagged.x-grid3-row-selected {
+  background-color: #f8e9c4 !important; }
+
 .x-toolbar {
   background-image: none;
   background-color: #ffffff;

--- a/client/zarafa/mail/ui/MailGrid.js
+++ b/client/zarafa/mail/ui/MailGrid.js
@@ -246,6 +246,12 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 	{
 		var cssClass = this.grid.getConversationCssClasses(record, rowIndex, store);
 
+		// Highlight the entire row for messages that carry a follow-up flag
+		// (Outlook-style), so a flagged/tracked mail stands out in the list.
+		if (record.get('flag_status') === Zarafa.core.mapi.FlagStatus.flagged) {
+			cssClass += ' k-flagged';
+		}
+
 		if (this.enableRowBody) {
 			var meta = {}; // Metadata object for Zarafa.common.ui.grid.Renderers.
 			var value = ''; // The value which must be rendered


### PR DESCRIPTION
### Summary
Messages with a follow-up flag ("tracking") now tint the **whole grid row** in the message list, instead of only surfacing the small flag icon. This matches how Outlook emphasises a flagged/tracked mail, making flagged items easy to spot at a glance.

### Motivation
In Outlook, flagging a message highlights the entire row so it stands out in a busy inbox. grommunio Web previously showed only the flag icon in the flag column, which is easy to miss — a flagged mail looked almost identical to an unflagged one.

### What changed
- `MailGrid.viewConfigGetRowClass` adds a `k-flagged` class to any row whose `flag_status` is `flagged` (completed flags are intentionally not highlighted, mirroring Outlook).
- CSS tints the flagged row a subtle amber. The tint **persists on hover and when the row is selected** (a touch deeper when selected), so a flagged mail stays highlighted after you click it; the existing blue left border still marks the selected row.
- Both light and dark themes are covered.
