### PR TITLE
fix: don't show a spurious colour category for follow-up flagged mails

### DIFF
--- a/client/zarafa/common/categories/Util.js
+++ b/client/zarafa/common/categories/Util.js
@@ -67,15 +67,19 @@ Zarafa.common.categories.Util = {
 			categories = record.get('categories').replace(/;?\s*$/, '').split('; ');
 		}
 
-		// Flags that are not 'follow-up' flags are set before we switched to the new categories/flags and will
-		// be shown as categories.
-		if ( record.get('flag_status')===Zarafa.core.mapi.FlagStatus.flagged && record.get('flag_request')!=='Follow up' ){
+		// Old-style coloured flags (set before follow-up flags existed, or by
+		// other clients) are shown as a category of the matching colour. A red
+		// flag is the modern follow-up / tracking flag - Outlook uses it in
+		// every locale and IMAP sets it too - so it must stay a flag only and
+		// never turn into a "Red" category. Keying off the icon (rather than a
+		// localised flag_request text) keeps this locale- and client-independent.
+		if ( record.get('flag_status')===Zarafa.core.mapi.FlagStatus.flagged && record.get('flag_icon')!==Zarafa.core.mapi.FlagIcon.red ){
 			var flagColor = record.get('flag_icon');
 			var flagCategoryName = this.getCategoryNameByFlagColor(flagColor);
 
 			// The flag could already be set as a real category. In that case
 			// we will not add it again.
-			if ( categories.indexOf(flagCategoryName) === -1 ){
+			if ( flagCategoryName && categories.indexOf(flagCategoryName) === -1 ){
 				categories.push(flagCategoryName);
 			}
 		}
@@ -301,7 +305,9 @@ Zarafa.common.categories.Util = {
 			// displayed as a category. This means that the category that
 			// is being removed could also be a flag!
 			// Note that the getCategories method has already added it.
-			if ( record.get('flag_status') === Zarafa.core.mapi.FlagStatus.flagged && record.get('flag_request')!=='Follow up' ){
+			// Mirror the icon-based discriminator used in getCategories: a red
+			// flag is the follow-up/tracking flag and is never a category.
+			if ( record.get('flag_status') === Zarafa.core.mapi.FlagStatus.flagged && record.get('flag_icon')!==Zarafa.core.mapi.FlagIcon.red ){
 				var flagColor = record.get('flag_icon');
 				var flagCategoryName = this.getCategoryNameByFlagColor(flagColor);
 				if ( flagCategoryName === category ){

--- a/client/zarafa/common/flags/Util.js
+++ b/client/zarafa/common/flags/Util.js
@@ -326,8 +326,10 @@ Zarafa.common.flags.Util = {
 		}
 		records.forEach(function(record){
 			const flagStatus = record.get('flag_status');
-			const flagRequest = record.get('flag_request');
-			if ( flagStatus===Zarafa.core.mapi.FlagStatus.flagged && flagRequest!=='Follow up'){
+			const flagIcon = record.get('flag_icon');
+			// Mirror getCategories: only non-red (old-style coloured) flags
+			// become categories; a red flag is a follow-up/tracking flag.
+			if ( flagStatus===Zarafa.core.mapi.FlagStatus.flagged && flagIcon!==Zarafa.core.mapi.FlagIcon.red){
 				const categories = Zarafa.common.categories.Util.getCategories(record);
 				Zarafa.common.categories.Util.setCategories(record, categories);
 			}


### PR DESCRIPTION
## Summary
A follow-up ("tracking") flag set in Outlook, or delivered over IMAP, was rendered in the message list as both a flag **and** a colour category — typically a red flag also showing a "Red" category. This PR makes a follow-up flag stay a flag only, matching Outlook, while preserving the old-style colour-flag → category migration for genuine colour flags.

## Cause
grommunio Web decided a flag was an "old-style colour flag" (and therefore should be shown as a category) whenever `flag_status` was flagged and `flag_request` was **not** the literal English string `'Follow up'`. That test is locale- and client-fragile: Outlook writes a localised `flag_request` (e.g. the German `"Zur Nachverfolgung"`), and IMAP writes none at all. In both cases a normal follow-up flag failed the `'Follow up'` check and was misclassified as a colour flag, so `getCategories()` synthesised a colour category from the flag icon. Since a follow-up flag uses the red icon, that surfaced as a phantom "Red" category next to the flag.

## Fix
Detect old-style colour flags by the **flag icon** instead of the `flag_request` text. A red flag is the follow-up/tracking flag in every client and locale, so a red flag now stays a flag only and never becomes a "Red" category. Non-red colour flags (blue, green, orange, yellow, purple) still convert to their matching category, so the legacy migration behaviour is unchanged. The same icon-based check is applied in all three places that shared the old discriminator, so display, category removal, and the flag-change materialisation stay consistent.


