### PR TITLE
Per-mailbox category lists (shared across a mailbox's users, Outlook-compatible

### DIFF
--- a/client/zarafa/Zarafa.js
+++ b/client/zarafa/Zarafa.js
@@ -848,6 +848,10 @@ Ext.apply(Zarafa, {
 			return;
 		}
 
+		// A store's list arrives asynchronously; re-render visible grids so a
+		// grid rendered before its list loaded picks up the correct colours.
+		manager.on('load', this.onCategoryListLoaded, this);
+
 		var hierarchyStore = container.getHierarchyStore();
 		var loadForRecords = function(records) {
 			Ext.each(records, function(storeRecord) {
@@ -864,6 +868,31 @@ Ext.apply(Zarafa, {
 		hierarchyStore.on('add', function(store, records) {
 			loadForRecords(records);
 		}, this);
+	},
+
+	/**
+	 * Handler for {@link Zarafa.common.categories.CategoryListManager#load}.
+	 * Re-renders any currently visible grid so category colours resolved
+	 * against a just-loaded per-mailbox list are applied. Best-effort and fully
+	 * guarded: a category list also applies on the next navigation regardless.
+	 * @private
+	 */
+	onCategoryListLoaded: function()
+	{
+		try {
+			var contentPanel = container.getContentPanel();
+			if ( !contentPanel || !Ext.isFunction(contentPanel.findByType) ) {
+				return;
+			}
+			Ext.each(contentPanel.findByType('grid'), function(grid) {
+				var view = Ext.isFunction(grid.getView) ? grid.getView() : null;
+				if ( view && Ext.isFunction(view.refresh) ) {
+					view.refresh();
+				}
+			});
+		} catch (e) {
+			// Ignore: the list will apply on the next grid render anyway.
+		}
 	},
 
 	/**

--- a/client/zarafa/Zarafa.js
+++ b/client/zarafa/Zarafa.js
@@ -829,6 +829,41 @@ Ext.apply(Zarafa, {
 
 		// Shared stores unread email poller
 		this.startSharedStoresHierarchyChecker();
+
+		// Preload the per-mailbox master category list for every open store.
+		this.prefetchCategoryLists();
+	},
+
+	/**
+	 * Preload the per-mailbox category list ({@link Zarafa.common.categories.CategoryListManager})
+	 * for every currently open store, and for any store opened later (e.g. a
+	 * shared mailbox). Each mailbox has its own list, so categories on its
+	 * messages resolve against that mailbox rather than the current user's.
+	 * @private
+	 */
+	prefetchCategoryLists: function()
+	{
+		var manager = Zarafa.common.categories.CategoryListManager;
+		if ( !manager ) {
+			return;
+		}
+
+		var hierarchyStore = container.getHierarchyStore();
+		var loadForRecords = function(records) {
+			Ext.each(records, function(storeRecord) {
+				var storeEntryId = storeRecord.get('store_entryid');
+				if ( storeEntryId ) {
+					manager.load(storeEntryId);
+				}
+			});
+		};
+
+		loadForRecords(hierarchyStore.getRange());
+
+		// Stores opened after boot (shared mailboxes) also get their list.
+		hierarchyStore.on('add', function(store, records) {
+			loadForRecords(records);
+		}, this);
 	},
 
 	/**

--- a/client/zarafa/common/Actions.js
+++ b/client/zarafa/common/Actions.js
@@ -269,6 +269,12 @@ Zarafa.common.Actions = {
 			modal: true
 		});
 
+		// The categories are managed per mailbox: edit the list of the mailbox
+		// the selected record(s) live in.
+		if ( !Ext.isDefined(config.storeEntryId) && Ext.isFunction(records[0].get) ) {
+			config.storeEntryId = records[0].get('store_entryid');
+		}
+
 		// Callback function added in config object if
 		// selected records is belongs to search store.
 		var store = records[0].getStore();

--- a/client/zarafa/common/categories/CategoryListManager.js
+++ b/client/zarafa/common/categories/CategoryListManager.js
@@ -1,0 +1,155 @@
+/*
+ * #dependsFile client/zarafa/common/categories/data/CategoriesStore.js
+ * #dependsFile client/zarafa/core/data/AbstractResponseHandler.js
+ */
+Ext.namespace('Zarafa.common.categories');
+
+/**
+ * @class Zarafa.common.categories.CategoryListManagerClass
+ * @extends Ext.util.Observable
+ *
+ * Loads, caches and saves the per-mailbox master category list. Each mailbox
+ * (store) has its own list, stored the Outlook-compatible way in the store's
+ * Calendar folder (see the server-side CategoryList/CategoryListModule), so the
+ * list is shared by every user of that mailbox. This manager keeps one
+ * {@link Zarafa.common.categories.data.CategoriesStore} per store entryid,
+ * populated from the server, and fires {@link #load} when a store's list
+ * arrives so views can refresh.
+ *
+ * @singleton (instantiated below as Zarafa.common.categories.CategoryListManager)
+ */
+Zarafa.common.categories.CategoryListManagerClass = Ext.extend(Ext.util.Observable, {
+	/**
+	 * Cache of per-store category stores, keyed by lower-cased store entryid.
+	 * @property
+	 * @type Object
+	 * @private
+	 */
+	stores: null,
+
+	/**
+	 * Set of store entryids (lower-cased) for which a request is in flight,
+	 * used to avoid firing duplicate requests.
+	 * @property
+	 * @type Object
+	 * @private
+	 */
+	loading: null,
+
+	/**
+	 * @constructor
+	 */
+	constructor: function()
+	{
+		this.stores = {};
+		this.loading = {};
+
+		this.addEvents(
+			/**
+			 * @event load
+			 * Fires when a store's category list has been loaded (or reloaded).
+			 * @param {Zarafa.common.categories.CategoryListManagerClass} manager
+			 * @param {String} storeEntryId The (lower-cased) store entryid
+			 * @param {Zarafa.common.categories.data.CategoriesStore} categoriesStore
+			 */
+			'load'
+		);
+
+		Zarafa.common.categories.CategoryListManagerClass.superclass.constructor.call(this);
+	},
+
+	/**
+	 * Normalise a store entryid for use as a cache key.
+	 * @param {String} storeEntryId
+	 * @return {String} the lower-cased entryid, or '' when empty
+	 * @private
+	 */
+	normalizeId: function(storeEntryId)
+	{
+		return storeEntryId ? storeEntryId.toLowerCase() : '';
+	},
+
+	/**
+	 * Return the cached category store for the given store entryid, or
+	 * undefined when it has not been loaded yet.
+	 * @param {String} storeEntryId
+	 * @return {Zarafa.common.categories.data.CategoriesStore|undefined}
+	 */
+	getCategoriesStore: function(storeEntryId)
+	{
+		return this.stores[this.normalizeId(storeEntryId)];
+	},
+
+	/**
+	 * Load the category list for the given store from the server. Does nothing
+	 * when it is already cached or a request is already in flight, unless
+	 * forceReload is true.
+	 * @param {String} storeEntryId The store entryid (hex)
+	 * @param {Boolean} forceReload (optional) reload even when already cached
+	 */
+	load: function(storeEntryId, forceReload)
+	{
+		var id = this.normalizeId(storeEntryId);
+		if ( !id ){
+			return;
+		}
+		if ( !forceReload && (this.stores[id] || this.loading[id]) ){
+			return;
+		}
+
+		this.loading[id] = true;
+		var responseHandler = new Zarafa.core.data.AbstractResponseHandler({
+			doList: this.onListResponse.createDelegate(this),
+			doUpdate: this.onListResponse.createDelegate(this)
+		});
+		container.getRequest().singleRequest('categorylistmodule', 'list', { store_entryid: storeEntryId }, responseHandler);
+	},
+
+	/**
+	 * Save the given category list for the given store back to the server. The
+	 * server merges it onto the stored list (preserving Outlook bookkeeping)
+	 * and returns the canonical result, which repopulates the cache.
+	 * @param {String} storeEntryId The store entryid (hex)
+	 * @param {Object[]} categories The category dicts to store
+	 */
+	save: function(storeEntryId, categories)
+	{
+		var responseHandler = new Zarafa.core.data.AbstractResponseHandler({
+			doList: this.onListResponse.createDelegate(this),
+			doUpdate: this.onListResponse.createDelegate(this)
+		});
+		container.getRequest().singleRequest('categorylistmodule', 'save', {
+			store_entryid: storeEntryId,
+			categories: categories
+		}, responseHandler);
+	},
+
+	/**
+	 * Handle a list/update response from the server: (re)build the per-store
+	 * {@link Zarafa.common.categories.data.CategoriesStore} and fire
+	 * {@link #load}.
+	 * @param {Object} response The action data ({store_entryid, categories})
+	 * @private
+	 */
+	onListResponse: function(response)
+	{
+		if ( !response || !response.store_entryid ){
+			return;
+		}
+		var id = this.normalizeId(response.store_entryid);
+		delete this.loading[id];
+
+		this.stores[id] = new Zarafa.common.categories.data.CategoriesStore({
+			categoriesData: response.categories || []
+		});
+
+		this.fireEvent('load', this, id, this.stores[id]);
+	}
+});
+
+/**
+ * @class Zarafa.common.categories.CategoryListManager
+ * The singleton instance of {@link Zarafa.common.categories.CategoryListManagerClass}.
+ * @singleton
+ */
+Zarafa.common.categories.CategoryListManager = new Zarafa.common.categories.CategoryListManagerClass();

--- a/client/zarafa/common/categories/CategoryListManager.js
+++ b/client/zarafa/common/categories/CategoryListManager.js
@@ -90,6 +90,31 @@ Zarafa.common.categories.CategoryListManagerClass = Ext.extend(Ext.util.Observab
 	},
 
 	/**
+	 * Return the cached category list for a store as plain category dicts, or
+	 * null when it has not been loaded yet (callers fall back to the per-user
+	 * list). Used to seed an editable per-mailbox CategoriesStore.
+	 * @param {String} storeEntryId
+	 * @return {Object[]|null}
+	 */
+	getCategoriesData: function(storeEntryId)
+	{
+		var store = this.getCategoriesStore(storeEntryId);
+		if ( !store ){
+			return null;
+		}
+		return store.getRange().map(function(categoryRecord){
+			return {
+				name: categoryRecord.get('category'),
+				color: categoryRecord.get('color'),
+				standardIndex: categoryRecord.get('standardIndex'),
+				quickAccess: categoryRecord.get('quickAccess'),
+				sortIndex: categoryRecord.get('sortIndex'),
+				used: categoryRecord.get('used')
+			};
+		});
+	},
+
+	/**
 	 * Load the category list for the given store from the server. Does nothing
 	 * when it is already cached or a request is already in flight, unless
 	 * forceReload is true.

--- a/client/zarafa/common/categories/CategoryListManager.js
+++ b/client/zarafa/common/categories/CategoryListManager.js
@@ -99,8 +99,8 @@ Zarafa.common.categories.CategoryListManagerClass = Ext.extend(Ext.util.Observab
 
 		this.loading[id] = true;
 		var responseHandler = new Zarafa.core.data.AbstractResponseHandler({
-			doList: this.onListResponse.createDelegate(this),
-			doUpdate: this.onListResponse.createDelegate(this)
+			doList: this.onListResponse.createDelegate(this, [id], true),
+			doUpdate: this.onListResponse.createDelegate(this, [id], true)
 		});
 		container.getRequest().singleRequest('categorylistmodule', 'list', { store_entryid: storeEntryId }, responseHandler);
 	},
@@ -114,9 +114,10 @@ Zarafa.common.categories.CategoryListManagerClass = Ext.extend(Ext.util.Observab
 	 */
 	save: function(storeEntryId, categories)
 	{
+		var id = this.normalizeId(storeEntryId);
 		var responseHandler = new Zarafa.core.data.AbstractResponseHandler({
-			doList: this.onListResponse.createDelegate(this),
-			doUpdate: this.onListResponse.createDelegate(this)
+			doList: this.onListResponse.createDelegate(this, [id], true),
+			doUpdate: this.onListResponse.createDelegate(this, [id], true)
 		});
 		container.getRequest().singleRequest('categorylistmodule', 'save', {
 			store_entryid: storeEntryId,
@@ -129,21 +130,41 @@ Zarafa.common.categories.CategoryListManagerClass = Ext.extend(Ext.util.Observab
 	 * {@link Zarafa.common.categories.data.CategoriesStore} and fire
 	 * {@link #load}.
 	 * @param {Object} response The action data ({store_entryid, categories})
+	 * @param {String} requestedId The (normalised) store entryid this request
+	 * was made with. Records and the hierarchy carry this id, whereas the server
+	 * echoes the store's canonical PR_ENTRYID; for shared stores the two differ,
+	 * so the list is cached under both to guarantee a lookup hit.
 	 * @private
 	 */
-	onListResponse: function(response)
+	onListResponse: function(response, requestedId)
 	{
-		if ( !response || !response.store_entryid ){
+		if ( !response ){
 			return;
 		}
-		var id = this.normalizeId(response.store_entryid);
-		delete this.loading[id];
 
-		this.stores[id] = new Zarafa.common.categories.data.CategoriesStore({
+		var categoriesStore = new Zarafa.common.categories.data.CategoriesStore({
 			categoriesData: response.categories || []
 		});
 
-		this.fireEvent('load', this, id, this.stores[id]);
+		var ids = [];
+		if ( requestedId ){
+			ids.push(requestedId);
+		}
+		if ( response.store_entryid ){
+			var responseId = this.normalizeId(response.store_entryid);
+			if ( ids.indexOf(responseId) === -1 ){
+				ids.push(responseId);
+			}
+		}
+
+		Ext.each(ids, function(id){
+			delete this.loading[id];
+			this.stores[id] = categoriesStore;
+		}, this);
+
+		if ( ids.length ){
+			this.fireEvent('load', this, ids[0], categoriesStore);
+		}
 	}
 });
 

--- a/client/zarafa/common/categories/CategoryListManager.js
+++ b/client/zarafa/common/categories/CategoryListManager.js
@@ -37,6 +37,15 @@ Zarafa.common.categories.CategoryListManagerClass = Ext.extend(Ext.util.Observab
 	loading: null,
 
 	/**
+	 * True once the one-time migration of the own mailbox's list has been
+	 * attempted this session, so it is not repeated.
+	 * @property
+	 * @type Boolean
+	 * @private
+	 */
+	seeded: false,
+
+	/**
 	 * @constructor
 	 */
 	constructor: function()
@@ -164,6 +173,47 @@ Zarafa.common.categories.CategoryListManagerClass = Ext.extend(Ext.util.Observab
 
 		if ( ids.length ){
 			this.fireEvent('load', this, ids[0], categoriesStore);
+		}
+
+		// One-time migration: give the user's own mailbox a real list by seeding
+		// its (empty) list from the per-user categories the user already has.
+		this.seedOwnStoreIfEmpty(ids, response.categories || []);
+	},
+
+	/**
+	 * If the just-loaded store is the user's own default store and it has no
+	 * stored category list yet, seed it from the existing per-user WebApp
+	 * categories (which already include the defaults) and save it back to the
+	 * mailbox. Runs at most once per session.
+	 * @param {String[]} ids The (normalised) entryids the loaded list was cached under
+	 * @param {Object[]} categories The categories that were loaded
+	 * @private
+	 */
+	seedOwnStoreIfEmpty: function(ids, categories)
+	{
+		if ( this.seeded || (categories && categories.length) ){
+			return;
+		}
+
+		var hierarchyStore = container.getHierarchyStore();
+		var defaultStore = hierarchyStore ? hierarchyStore.getDefaultStore() : null;
+		if ( !defaultStore ){
+			return;
+		}
+
+		var ownEntryId = defaultStore.get('store_entryid');
+		if ( ids.indexOf(this.normalizeId(ownEntryId)) === -1 ){
+			return; // the loaded store is not the user's own default store
+		}
+
+		this.seeded = true;
+
+		var seed = container.getPersistentSettingsModel().get('grommunio/main/categories') || [];
+		if ( !seed.length ){
+			seed = container.getServerConfig().getDefaultCategories() || [];
+		}
+		if ( seed.length ){
+			this.save(ownEntryId, seed);
 		}
 	}
 });

--- a/client/zarafa/common/categories/Util.js
+++ b/client/zarafa/common/categories/Util.js
@@ -71,7 +71,7 @@ Zarafa.common.categories.Util = {
 		// be shown as categories.
 		if ( record.get('flag_status')===Zarafa.core.mapi.FlagStatus.flagged && record.get('flag_request')!=='Follow up' ){
 			var flagColor = record.get('flag_icon');
-			var flagCategoryName = this.getCategoryNameByFlagColor(flagColor);
+			var flagCategoryName = this.getCategoryNameByFlagColor(flagColor, record.get('store_entryid'));
 
 			// The flag could already be set as a real category. In that case
 			// we will not add it again.
@@ -99,18 +99,15 @@ Zarafa.common.categories.Util = {
 			}
 		}
 
-		// Instantiate the category store only once. If any changes are done to the
-		// managed category list, the code that did the change must call {#loadCategoriesStore}!
-		if ( !this.categoriesStore ){
-			this.loadCategoriesStore();
-		}
-
-		// If a category exists in the managed category list we must make sure we will use
-		// the name in the list to avoid case sensitivity issues.
+		// If a category exists in the managed category list we must make sure we
+		// will use the name in the list to avoid case sensitivity issues. Resolve
+		// against the record's own mailbox list so items in a shared mailbox
+		// normalise against that mailbox rather than the current user's list.
+		var categoriesStore = this.getCategoriesStoreForId(record.get('store_entryid'));
 		categories = categories.map(function(category){
-			var index = this.categoriesStore.findExactCaseInsensitive('category', category);
+			var index = categoriesStore.findExactCaseInsensitive('category', category);
 			if ( index>=0 ){
-				return this.categoriesStore.getAt(index).get('category');
+				return categoriesStore.getAt(index).get('category');
 			}
 
 			return category;
@@ -336,8 +333,23 @@ Zarafa.common.categories.Util = {
 	 * @param {Zarafa.core.mapi.FlagIcon} flagColorIndex The flag color
 	 * @return {String} The matching category name
 	 */
-	getCategoryNameByFlagColor: function(flagColorIndex)
+	getCategoryNameByFlagColor: function(flagColorIndex, storeEntryId)
 	{
+		// Prefer the per-mailbox list when it has been loaded.
+		if ( storeEntryId && Zarafa.common.categories.CategoryListManager ){
+			var perStore = Zarafa.common.categories.CategoryListManager.getCategoriesStore(storeEntryId);
+			if ( perStore ){
+				var name = '';
+				perStore.each(function(category){
+					if ( category.get('standardIndex') === flagColorIndex ){
+						name = category.get('category');
+						return false;
+					}
+				});
+				return name;
+			}
+		}
+
 		var settingsModel = container.getPersistentSettingsModel();
 		var categories = settingsModel.get('grommunio/main/categories', true);
 		var retVal = '';
@@ -358,22 +370,49 @@ Zarafa.common.categories.Util = {
 	},
 
 	/**
-	 * Returns the color (css) for the given category
+	 * Returns the {@link Zarafa.common.categories.data.CategoriesStore} that holds
+	 * the available categories for the given mailbox. When that mailbox's list has
+	 * been loaded by {@link Zarafa.common.categories.CategoryListManager} it is
+	 * used; otherwise the shared per-user store is returned as a fallback.
 	 *
-	 * @param {String} category The category name
-	 * @return {String} The color of the category (hex code)
+	 * @param {String} storeEntryId (optional) The entryid of the mailbox
+	 * @return {Zarafa.common.categories.data.CategoriesStore}
 	 */
-	getCategoryColor: function(category)
+	getCategoriesStoreForId: function(storeEntryId)
 	{
-		// Instantiate the category store only once. If any changes are done to the
-		// categories, the code that did the change must call {#loadCategoriesStore}!
+		if ( storeEntryId && Zarafa.common.categories.CategoryListManager ){
+			var perStore = Zarafa.common.categories.CategoryListManager.getCategoriesStore(storeEntryId);
+			if ( perStore ){
+				return perStore;
+			}
+		}
+
+		// Instantiate the fallback (per-user) category store only once. If any
+		// changes are done to it, the code that did the change must call
+		// {#loadCategoriesStore}!
 		if ( !this.categoriesStore ){
 			this.loadCategoriesStore();
 		}
 
-		var catIndex = this.categoriesStore.findExactCaseInsensitive('category', category);
+		return this.categoriesStore;
+	},
+
+	/**
+	 * Returns the color (css) for the given category
+	 *
+	 * @param {String} category The category name
+	 * @param {String} storeEntryId (optional) The entryid of the mailbox whose
+	 * category list should resolve the colour. When omitted (or not yet loaded)
+	 * the shared per-user list is used.
+	 * @return {String} The color of the category (hex code)
+	 */
+	getCategoryColor: function(category, storeEntryId)
+	{
+		var categoriesStore = this.getCategoriesStoreForId(storeEntryId);
+
+		var catIndex = categoriesStore.findExactCaseInsensitive('category', category);
 		if ( catIndex > -1 ){
-			return this.categoriesStore.getAt(catIndex).get('color');
+			return categoriesStore.getAt(catIndex).get('color');
 		}
 
 		return Zarafa.common.categories.Util.defaultCategoryColor;
@@ -410,7 +449,7 @@ Zarafa.common.categories.Util = {
 	 * @param {String} categories The category name
 	 * @return {String} The html of the categories as colored blocks
 	 */
-	getCategoriesHtml: function(categories)
+	getCategoriesHtml: function(categories, storeEntryId)
 	{
 		// Compile the template string if not done yet
 		if (Ext.isString(this.categoriesHtmlTemplate)) {
@@ -422,7 +461,7 @@ Zarafa.common.categories.Util = {
 		var data = categories.map(function(category){
 			var dataEntry = {
 				name: Ext.util.Format.htmlEncode(category),
-				backgroundColor: this.getCategoryColor(category)
+				backgroundColor: this.getCategoryColor(category, storeEntryId)
 			};
 			if ( dataEntry.backgroundColor ){
 				dataEntry.colorClass = Zarafa.core.ColorSchemes.getLuma(dataEntry.backgroundColor) < 200 ? 'zarafa-dark' : '';

--- a/client/zarafa/common/categories/data/CategoriesStore.js
+++ b/client/zarafa/common/categories/data/CategoriesStore.js
@@ -31,11 +31,17 @@ Zarafa.common.categories.data.CategoriesStore = Ext.extend(Ext.data.ArrayStore, 
 		config = config || {};
 		var categories = [];
 
-		// When a categoriesData array is supplied (e.g. a per-mailbox list
-		// loaded from the store's IPM.Configuration.CategoryList), use it as the
-		// source instead of the per-user WebApp settings. The admin additional
-		// categories and insertion points below are still applied on top.
-		var storedCategories = config.categoriesData || container.getPersistentSettingsModel().get(this.settingsKey);
+		// Source the categories from, in order: an explicit categoriesData array,
+		// the per-mailbox list for config.storeEntryId (the Outlook-compatible
+		// list in that mailbox), or the per-user WebApp settings. The admin
+		// additional categories and insertion points below are applied on top.
+		var storedCategories = config.categoriesData;
+		if ( !storedCategories && config.storeEntryId && Zarafa.common.categories.CategoryListManager ) {
+			storedCategories = Zarafa.common.categories.CategoryListManager.getCategoriesData(config.storeEntryId);
+		}
+		if ( !storedCategories ) {
+			storedCategories = container.getPersistentSettingsModel().get(this.settingsKey);
+		}
 		delete config.categoriesData;
 		if ( storedCategories ) {
 			categories = categories.concat(storedCategories);
@@ -127,10 +133,28 @@ Zarafa.common.categories.data.CategoriesStore = Ext.extend(Ext.data.ArrayStore, 
 	},
 
 	/**
-	 * Saves the categories in the store into the settings of the user
+	 * Saves the categories in the store. For a per-mailbox store (one created
+	 * with a storeEntryId) the whole list is written to that mailbox's master
+	 * category list via {@link Zarafa.common.categories.CategoryListManager};
+	 * otherwise it is saved to the per-user WebApp settings.
 	 */
 	save: function()
 	{
+		if ( this.storeEntryId && Zarafa.common.categories.CategoryListManager ) {
+			var mailboxCategories = this.getRange().map(function(categoryRecord){
+				return {
+					name: categoryRecord.get('category'),
+					color: categoryRecord.get('color'),
+					standardIndex: categoryRecord.get('standardIndex'),
+					quickAccess: categoryRecord.get('quickAccess'),
+					sortIndex: categoryRecord.get('sortIndex'),
+					used: categoryRecord.get('used')
+				};
+			});
+			Zarafa.common.categories.CategoryListManager.save(this.storeEntryId, mailboxCategories);
+			return;
+		}
+
 		var categories = this.getRange().filter(function(categoryRecord){
 			// Only save categories that were already stored before,
 			// or that have been pinned or were given a color by the user

--- a/client/zarafa/common/categories/data/CategoriesStore.js
+++ b/client/zarafa/common/categories/data/CategoriesStore.js
@@ -31,9 +31,14 @@ Zarafa.common.categories.data.CategoriesStore = Ext.extend(Ext.data.ArrayStore, 
 		config = config || {};
 		var categories = [];
 
-		var storedCategories = container.getPersistentSettingsModel().get(this.settingsKey);
+		// When a categoriesData array is supplied (e.g. a per-mailbox list
+		// loaded from the store's IPM.Configuration.CategoryList), use it as the
+		// source instead of the per-user WebApp settings. The admin additional
+		// categories and insertion points below are still applied on top.
+		var storedCategories = config.categoriesData || container.getPersistentSettingsModel().get(this.settingsKey);
+		delete config.categoriesData;
 		if ( storedCategories ) {
-			categories = categories.concat(container.getPersistentSettingsModel().get(this.settingsKey));
+			categories = categories.concat(storedCategories);
 		}
 		categories = categories.concat(container.populateInsertionPoint('main.categories'));
 

--- a/client/zarafa/common/categories/dialogs/CategoriesContentPanel.js
+++ b/client/zarafa/common/categories/dialogs/CategoriesContentPanel.js
@@ -72,6 +72,7 @@ Zarafa.common.categories.dialogs.CategoriesContentPanel = Ext.extend(Zarafa.core
 			items: [{
 				xtype: 'zarafa.categoriespanel',
 				record: config.record,
+				storeEntryId: config.storeEntryId,
 				ref: 'categoriesPanel',
 				buttons: [{
 					text: _('Apply'),
@@ -175,9 +176,11 @@ Zarafa.common.categories.dialogs.CategoriesContentPanel = Ext.extend(Zarafa.core
 	 */
 	onNew: function()
 	{
+		var gridStore = this.categoriesPanel.categoriesGrid.getStore();
 		Zarafa.common.Actions.openNewCategoryContent({
-			store: this.categoriesPanel.categoriesGrid.getStore(),
-			grid: this.categoriesPanel.categoriesGrid
+			store: gridStore,
+			grid: this.categoriesPanel.categoriesGrid,
+			storeEntryId: gridStore.storeEntryId
 		});
 	},
 

--- a/client/zarafa/common/categories/dialogs/CategoriesPanel.js
+++ b/client/zarafa/common/categories/dialogs/CategoriesPanel.js
@@ -42,7 +42,7 @@ Zarafa.common.categories.dialogs.CategoriesPanel = Ext.extend(Ext.Panel, {
 			layout: 'fit',
 			border: false,
 			items: [
-				this.createCategoriesGrid(config.record)
+				this.createCategoriesGrid(config.record, config.storeEntryId)
 			]
 		});
 
@@ -56,9 +56,11 @@ Zarafa.common.categories.dialogs.CategoriesPanel = Ext.extend(Ext.Panel, {
 	 * @return {Object} The configuration object for the grid panel.
 	 * @private
 	 */
-	createCategoriesGrid: function(records)
+	createCategoriesGrid: function(records, storeEntryId)
 	{
-		var store = new Zarafa.common.categories.data.CategoriesStore();
+		var store = new Zarafa.common.categories.data.CategoriesStore(
+			storeEntryId ? { storeEntryId: storeEntryId } : undefined
+		);
 		store.addCategoriesFromMapiRecords(records);
 		store.sort([
 			{field: 'quickAccess', direction: 'DESC'},

--- a/client/zarafa/common/categories/dialogs/NewCategoryPanel.js
+++ b/client/zarafa/common/categories/dialogs/NewCategoryPanel.js
@@ -16,6 +16,12 @@ Zarafa.common.categories.dialogs.NewCategoryPanel = Ext.extend(Zarafa.core.ui.Co
 	store: null,
 
 	/**
+	 * @cfg {String} storeEntryId The entryid of the mailbox whose category list
+	 * the new category should be added to. Used when no {@link #store} is given.
+	 */
+	storeEntryId: null,
+
+	/**
 	 * @constructor
 	 * @param {Object} config Configuration object
 	 */
@@ -128,22 +134,26 @@ Zarafa.common.categories.dialogs.NewCategoryPanel = Ext.extend(Zarafa.core.ui.Co
 			return;
 		}
 
-		var categoryStore = new Zarafa.common.categories.data.CategoriesStore();
 		var categoryColor = this.formPanel.color.getValue();
 		var quickAccess = this.formPanel.pin.getValue();
 
-		// Add the new category to our temporary store and use it to save it.
-		categoryStore.addCategory(categoryName, categoryColor, quickAccess);
-		categoryStore.save();
-
-		// Also add the new category to the store of the grid in the manage category dialog
+		// Write to the manage dialog's store when present (it is the per-mailbox
+		// list); otherwise create a store for the active mailbox. Either way the
+		// new category lands in the right mailbox's list.
 		if ( Ext.isDefined(this.store) ){
 			this.store.addCategory(categoryName, categoryColor, quickAccess);
+			this.store.save();
 
 			// scroll the new category into view, put the focus on it and select it
 			var rowIndex = this.store.findExact('category', categoryName);
 			this.grid.getView().focusRow(rowIndex);
 			this.grid.getSelectionModel().selectRow(rowIndex, true);
+		} else {
+			var categoryStore = new Zarafa.common.categories.data.CategoriesStore(
+				this.storeEntryId ? { storeEntryId: this.storeEntryId } : undefined
+			);
+			categoryStore.addCategory(categoryName, categoryColor, quickAccess);
+			categoryStore.save();
 		}
 
 		// Update the categoriesStore in Zarafa.common.categories.Util to make sure

--- a/client/zarafa/common/ui/grid/Renderers.js
+++ b/client/zarafa/common/ui/grid/Renderers.js
@@ -172,9 +172,11 @@ Zarafa.common.ui.grid.Renderers = {
 	 */
 	categories: function(value, p, record)
 	{
-		// Render the categories
+		// Render the categories, resolving colours against the record's own
+		// mailbox category list (per-mailbox, Outlook-compatible).
+		var storeEntryId = record && Ext.isFunction(record.get) ? record.get('store_entryid') : undefined;
 		var categories = Zarafa.common.categories.Util.getCategories(record);
-		return Zarafa.common.categories.Util.getCategoriesHtml(categories);
+		return Zarafa.common.categories.Util.getCategoriesHtml(categories, storeEntryId);
 	},
 
 	/**

--- a/client/zarafa/common/ui/messagepanel/CategoryLinks.js
+++ b/client/zarafa/common/ui/messagepanel/CategoryLinks.js
@@ -97,9 +97,10 @@ Zarafa.common.ui.messagepanel.CategoryLinks = Ext.extend(Ext.Container, {
 				this.el.dom.innerHTML = '';
 				return;
 			}
-			// Render the categories
+			// Render the categories, resolving colours against the record's own
+			// mailbox category list.
 			var categories = Zarafa.common.categories.Util.getCategories(record);
-			var html = Zarafa.common.categories.Util.getCategoriesHtml(categories);
+			var html = Zarafa.common.categories.Util.getCategoriesHtml(categories, record.get('store_entryid'));
 			this.el.dom.innerHTML = html;
 		}
 	}

--- a/client/zarafa/mail/ui/MailGrid.js
+++ b/client/zarafa/mail/ui/MailGrid.js
@@ -255,7 +255,7 @@ Zarafa.mail.ui.MailGrid = Ext.extend(Zarafa.common.ui.grid.MapiMessageGrid, {
 				// Render the categories
 				cssClass += ' with-categories';
 				var categories = Zarafa.common.categories.Util.getCategories(record);
-				var categoriesHtml = Zarafa.common.categories.Util.getCategoriesHtml(categories);
+				var categoriesHtml = Zarafa.common.categories.Util.getCategoriesHtml(categories, record.get('store_entryid'));
 				rowParams.body += '<div class="k-category-add-container"><span class="k-category-add"></span></div><div class="k-category-container">' + categoriesHtml + '</div>';
 			}
 

--- a/server/includes/core/class.categorylist.php
+++ b/server/includes/core/class.categorylist.php
@@ -114,15 +114,24 @@ class CategoryList {
 	 */
 	private function getCalendarFolder() {
 		if ($this->calendar === false) {
-			$root = mapi_msgstore_openentry($this->store, null);
-			if (!$root) {
+			try {
+				$root = mapi_msgstore_openentry($this->store);
+				if (!$root) {
+					return false;
+				}
+				$props = mapi_getprops($root, [PR_IPM_APPOINTMENT_ENTRYID]);
+				if (empty($props[PR_IPM_APPOINTMENT_ENTRYID])) {
+					return false;
+				}
+				$this->calendar = mapi_msgstore_openentry($this->store, $props[PR_IPM_APPOINTMENT_ENTRYID]);
+			}
+			catch (MAPIException $e) {
+				// A store without an accessible Calendar (e.g. the public
+				// store) simply has no category list; treat it as empty.
+				$e->setHandled();
+
 				return false;
 			}
-			$props = mapi_getprops($root, [PR_IPM_APPOINTMENT_ENTRYID]);
-			if (empty($props[PR_IPM_APPOINTMENT_ENTRYID])) {
-				return false;
-			}
-			$this->calendar = mapi_msgstore_openentry($this->store, $props[PR_IPM_APPOINTMENT_ENTRYID]);
 		}
 
 		return $this->calendar;
@@ -140,24 +149,30 @@ class CategoryList {
 			return false;
 		}
 
-		$table = mapi_folder_getcontentstable($calendar, MAPI_ASSOCIATED);
-		$restriction = [RES_PROPERTY, [
-			RELOP => RELOP_EQ,
-			ULPROPTAG => PR_MESSAGE_CLASS,
-			VALUE => [PR_MESSAGE_CLASS => self::MESSAGE_CLASS],
-		]];
-		mapi_table_restrict($table, $restriction);
-		$rows = mapi_table_queryallrows($table, [PR_ENTRYID]);
+		try {
+			$table = mapi_folder_getcontentstable($calendar, MAPI_ASSOCIATED);
+			$restriction = [RES_PROPERTY, [
+				RELOP => RELOP_EQ,
+				ULPROPTAG => PR_MESSAGE_CLASS,
+				VALUE => [PR_MESSAGE_CLASS => self::MESSAGE_CLASS],
+			]];
+			mapi_table_restrict($table, $restriction);
+			$rows = mapi_table_queryallrows($table, [PR_ENTRYID]);
 
-		if (!empty($rows)) {
-			return mapi_msgstore_openentry($this->store, $rows[0][PR_ENTRYID]);
+			if (!empty($rows)) {
+				return mapi_msgstore_openentry($this->store, $rows[0][PR_ENTRYID]);
+			}
+
+			if ($create) {
+				$message = mapi_folder_createmessage($calendar, MAPI_ASSOCIATED);
+				mapi_setprops($message, [PR_MESSAGE_CLASS => self::MESSAGE_CLASS]);
+
+				return $message;
+			}
 		}
-
-		if ($create) {
-			$message = mapi_folder_createmessage($calendar, MAPI_ASSOCIATED);
-			mapi_setprops($message, [PR_MESSAGE_CLASS => self::MESSAGE_CLASS]);
-
-			return $message;
+		catch (MAPIException $e) {
+			// No accessible associated store / config message; treat as empty.
+			$e->setHandled();
 		}
 
 		return false;

--- a/server/includes/core/class.categorylist.php
+++ b/server/includes/core/class.categorylist.php
@@ -1,0 +1,473 @@
+<?php
+
+/**
+ * CategoryList - the per-mailbox master category list.
+ *
+ * Outlook/Exchange store the list of available categories (name + colour) once
+ * per mailbox, as a hidden associated (FAI) message of class
+ * "IPM.Configuration.CategoryList" in the mailbox's Calendar folder. The
+ * definitions live in the PR_ROAMING_XMLSTREAM property as an XML document.
+ * Because it is stored in the mailbox itself, every client - and every user who
+ * opens that mailbox - shares the same list. grommunio Web historically kept
+ * its category list in per-user WebApp settings instead; this class reads and
+ * writes the Outlook-compatible per-mailbox list so the two interoperate.
+ *
+ * The class speaks the grommunio Web category shape
+ * ({name, color, standardIndex, quickAccess, sortIndex, used}) on its public
+ * API and the Outlook XML shape on disk, translating between them. Outlook's
+ * per-category bookkeeping (guid, usageCount, lastTimeUsed*, keyboardShortcut,
+ * renameOnFirstUse) is preserved verbatim across web edits by merging incoming
+ * categories onto the categories already stored, matched by guid then by name.
+ */
+class CategoryList {
+	/**
+	 * Message class of the FAI configuration message holding the list.
+	 */
+	const MESSAGE_CLASS = 'IPM.Configuration.CategoryList';
+
+	/**
+	 * grommunio Web's placeholder colour for "no colour chosen". Categories
+	 * carrying it are treated as uncoloured rather than mapped to the palette.
+	 */
+	const DEFAULT_COLOR = '#BDC3C7';
+
+	/**
+	 * Outlook OlCategoryColor palette: index (as written in the XML `color`
+	 * attribute) => RGB hex used to render the swatch. The first entries reuse
+	 * grommunio Web's own hex values for the six flag-mapped colours so the UI
+	 * renders them unchanged; the remainder are close approximations of
+	 * Outlook's palette and can be tuned without touching any other code.
+	 */
+	private static $palette = [
+		0  => '#e40023', // Red
+		1  => '#f99406', // Orange
+		2  => '#fbd5a6', // Peach
+		3  => '#f7ca17', // Yellow
+		4  => '#5ab556', // Green
+		5  => '#26a0a0', // Teal
+		6  => '#a4b34d', // Olive
+		7  => '#0f70bd', // Blue
+		8  => '#912887', // Purple
+		9  => '#a6014e', // Maroon
+		10 => '#9da3af', // Steel
+		11 => '#64738b', // Dark Steel
+		12 => '#b0b0b0', // Gray
+		13 => '#6e6e6e', // Dark Gray
+		14 => '#4c4c4c', // Black
+		15 => '#8c1015', // Dark Red
+		16 => '#c15a00', // Dark Orange
+		17 => '#c79860', // Dark Peach
+		18 => '#b8860b', // Dark Yellow
+		19 => '#2e7d32', // Dark Green
+		20 => '#00695c', // Dark Teal
+		21 => '#6b7a2e', // Dark Olive
+		22 => '#0a4c88', // Dark Blue
+		23 => '#5e1a59', // Dark Purple
+		24 => '#6e0033', // Dark Maroon
+	];
+
+	/**
+	 * Hex colour => grommunio Web standardIndex (the colour-flag mapping used to
+	 * show an old-style coloured flag as a category). Only the six standard
+	 * flag colours have one.
+	 */
+	private static $standardIndexByHex = [
+		'#e40023' => 6, // Red flag
+		'#f99406' => 2, // Orange flag
+		'#f7ca17' => 4, // Yellow flag
+		'#5ab556' => 3, // Green flag
+		'#0f70bd' => 5, // Blue flag
+		'#912887' => 1, // Purple flag
+	];
+
+	/**
+	 * @var resource The message store whose category list this instance manages.
+	 */
+	private $store;
+
+	/**
+	 * @var resource|false Cached Calendar folder, or false before it is opened.
+	 */
+	private $calendar = false;
+
+	/**
+	 * @param resource $store The (own or shared) message store to operate on.
+	 */
+	public function __construct($store) {
+		$this->store = $store;
+	}
+
+	/**
+	 * The proptag for PR_ROAMING_XMLSTREAM (Pt_BINARY, 0x7C08). php-mapi does
+	 * not predefine it, so compute it once here.
+	 *
+	 * @return int
+	 */
+	private static function roamingXmlStreamTag() {
+		return mapi_prop_tag(PT_BINARY, 0x7C08);
+	}
+
+	/**
+	 * Open the store's Calendar folder, where the list is stored.
+	 *
+	 * @return resource|false The Calendar folder, or false when unavailable.
+	 */
+	private function getCalendarFolder() {
+		if ($this->calendar === false) {
+			$root = mapi_msgstore_openentry($this->store, null);
+			if (!$root) {
+				return false;
+			}
+			$props = mapi_getprops($root, [PR_IPM_APPOINTMENT_ENTRYID]);
+			if (empty($props[PR_IPM_APPOINTMENT_ENTRYID])) {
+				return false;
+			}
+			$this->calendar = mapi_msgstore_openentry($this->store, $props[PR_IPM_APPOINTMENT_ENTRYID]);
+		}
+
+		return $this->calendar;
+	}
+
+	/**
+	 * Find the FAI configuration message that holds the list.
+	 *
+	 * @param bool $create create the message when it does not exist yet
+	 * @return resource|false the message, or false when absent (and not created)
+	 */
+	private function findConfigMessage($create = false) {
+		$calendar = $this->getCalendarFolder();
+		if (!$calendar) {
+			return false;
+		}
+
+		$table = mapi_folder_getcontentstable($calendar, MAPI_ASSOCIATED);
+		$restriction = [RES_PROPERTY, [
+			RELOP => RELOP_EQ,
+			ULPROPTAG => PR_MESSAGE_CLASS,
+			VALUE => [PR_MESSAGE_CLASS => self::MESSAGE_CLASS],
+		]];
+		mapi_table_restrict($table, $restriction);
+		$rows = mapi_table_queryallrows($table, [PR_ENTRYID]);
+
+		if (!empty($rows)) {
+			return mapi_msgstore_openentry($this->store, $rows[0][PR_ENTRYID]);
+		}
+
+		if ($create) {
+			$message = mapi_folder_createmessage($calendar, MAPI_ASSOCIATED);
+			mapi_setprops($message, [PR_MESSAGE_CLASS => self::MESSAGE_CLASS]);
+
+			return $message;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Read the raw category-list XML.
+	 *
+	 * @return string the XML document, or '' when no list is stored yet
+	 */
+	public function getXml() {
+		$message = $this->findConfigMessage(false);
+		if (!$message) {
+			return '';
+		}
+
+		$tag = self::roamingXmlStreamTag();
+		$props = mapi_getprops($message, [$tag]);
+		if (isset($props[$tag]) && is_string($props[$tag])) {
+			return $props[$tag];
+		}
+
+		// Large binaries come back as an error placeholder; read via a stream.
+		$stream = mapi_openproperty($message, $tag, IID_IStream, 0, 0);
+		if (!$stream) {
+			return '';
+		}
+		$xml = '';
+		$stat = mapi_stream_stat($stream);
+		mapi_stream_seek($stream, 0, STREAM_SEEK_SET);
+		for ($read = 0; $read < $stat['cb']; ) {
+			$chunk = mapi_stream_read($stream, 8192);
+			if ($chunk === '' || $chunk === false) {
+				break;
+			}
+			$xml .= $chunk;
+			$read += strlen($chunk);
+		}
+
+		return $xml;
+	}
+
+	/**
+	 * Write the raw category-list XML, creating the FAI message if needed.
+	 *
+	 * @param string $xml the XML document to store
+	 */
+	public function setXml($xml) {
+		$message = $this->findConfigMessage(true);
+		if (!$message) {
+			return;
+		}
+		mapi_setprops($message, [
+			PR_MESSAGE_CLASS => self::MESSAGE_CLASS,
+			self::roamingXmlStreamTag() => $xml,
+		]);
+		mapi_savechanges($message);
+	}
+
+	/**
+	 * Return the categories in grommunio Web shape.
+	 *
+	 * @return array a list of associative arrays with keys name, color,
+	 *               standardIndex, quickAccess, sortIndex, used, guid
+	 */
+	public function getCategories() {
+		$nodes = $this->parseXml($this->getXml());
+		$categories = [];
+		foreach ($nodes as $index => $node) {
+			$colorIndex = isset($node['color']) && $node['color'] !== '' ? (int) $node['color'] : -1;
+			$hex = self::colorIndexToHex($colorIndex);
+			$categories[] = [
+				'name' => isset($node['name']) ? $node['name'] : '',
+				'color' => $hex,
+				'standardIndex' => self::hexToStandardIndex($hex),
+				// grommunio-only fields are carried in custom x- attributes so
+				// they survive a round trip through the shared list.
+				'quickAccess' => isset($node['x-quickaccess']) ? $node['x-quickaccess'] === '1' : false,
+				'sortIndex' => isset($node['x-sortindex']) ? (int) $node['x-sortindex'] : ($index + 1),
+				'used' => isset($node['x-used']) ? $node['x-used'] === '1' : false,
+				'guid' => isset($node['guid']) ? $node['guid'] : '',
+			];
+		}
+
+		return $categories;
+	}
+
+	/**
+	 * Store the given categories, preserving each existing category's Outlook
+	 * bookkeeping (matched by guid, then by case-insensitive name).
+	 *
+	 * @param array $categories grommunio Web category dicts (name, color, ...)
+	 */
+	public function setCategories($categories) {
+		$existing = $this->parseXml($this->getXml());
+		$byGuid = [];
+		$byName = [];
+		foreach ($existing as $node) {
+			if (!empty($node['guid'])) {
+				$byGuid[strtolower($node['guid'])] = $node;
+			}
+			if (isset($node['name'])) {
+				$byName[strtolower($node['name'])] = $node;
+			}
+		}
+
+		$nodes = [];
+		foreach ($categories as $i => $category) {
+			$name = isset($category['name']) ? (string) $category['name'] : '';
+			if ($name === '') {
+				continue;
+			}
+			$guid = !empty($category['guid']) ? $category['guid'] : '';
+
+			// Start from the existing node so Outlook's attributes are kept.
+			$node = [];
+			if ($guid !== '' && isset($byGuid[strtolower($guid)])) {
+				$node = $byGuid[strtolower($guid)];
+			}
+			elseif (isset($byName[strtolower($name)])) {
+				$node = $byName[strtolower($name)];
+			}
+
+			if (empty($node['guid'])) {
+				$node['guid'] = $guid !== '' ? $guid : self::newGuid();
+			}
+			$node['name'] = $name;
+
+			// Only recompute the colour index when the hex actually changed, so
+			// an untouched Outlook colour keeps its exact original index.
+			$hex = isset($category['color']) ? strtolower($category['color']) : '';
+			$prevIndex = isset($node['color']) && $node['color'] !== '' ? (int) $node['color'] : -1;
+			if ($hex === '' || $hex === strtolower(self::DEFAULT_COLOR)) {
+				$node['color'] = $prevIndex >= 0 ? (string) $prevIndex : '';
+			}
+			elseif ($prevIndex >= 0 && strtolower(self::colorIndexToHex($prevIndex)) === $hex) {
+				$node['color'] = (string) $prevIndex;
+			}
+			else {
+				$node['color'] = (string) self::hexToColorIndex($hex);
+			}
+
+			// Sensible defaults for attributes Outlook expects.
+			if (!isset($node['keyboardShortcut'])) {
+				$node['keyboardShortcut'] = '0';
+			}
+			if (!isset($node['renameOnFirstUse'])) {
+				$node['renameOnFirstUse'] = '0';
+			}
+
+			// grommunio-only fields, namespaced so Outlook ignores them.
+			$node['x-quickaccess'] = !empty($category['quickAccess']) ? '1' : '0';
+			$node['x-used'] = !empty($category['used']) ? '1' : '0';
+			$node['x-sortindex'] = (string) (isset($category['sortIndex']) ? (int) $category['sortIndex'] : $i);
+
+			$nodes[] = $node;
+		}
+
+		$this->setXml($this->buildXml($nodes));
+	}
+
+	/**
+	 * Map an Outlook colour index to an RGB hex string.
+	 *
+	 * @param int $index palette index, or -1 for no colour
+	 * @return string hex colour (grommunio's default placeholder when unmapped)
+	 */
+	public static function colorIndexToHex($index) {
+		if (isset(self::$palette[$index])) {
+			return self::$palette[$index];
+		}
+
+		return self::DEFAULT_COLOR;
+	}
+
+	/**
+	 * Map an RGB hex string to the nearest Outlook colour index.
+	 *
+	 * @param string $hex the RGB hex string (with or without leading #)
+	 * @return int the matching or nearest palette index
+	 */
+	public static function hexToColorIndex($hex) {
+		$hex = strtolower(ltrim($hex, '#'));
+		foreach (self::$palette as $index => $paletteHex) {
+			if (ltrim($paletteHex, '#') === $hex) {
+				return $index;
+			}
+		}
+
+		// No exact match: pick the nearest palette colour by RGB distance.
+		$target = self::hexToRgb($hex);
+		if ($target === null) {
+			return 0;
+		}
+		$best = 0;
+		$bestDistance = PHP_INT_MAX;
+		foreach (self::$palette as $index => $paletteHex) {
+			$rgb = self::hexToRgb(ltrim($paletteHex, '#'));
+			$distance = ($rgb[0] - $target[0]) ** 2 + ($rgb[1] - $target[1]) ** 2 + ($rgb[2] - $target[2]) ** 2;
+			if ($distance < $bestDistance) {
+				$bestDistance = $distance;
+				$best = $index;
+			}
+		}
+
+		return $best;
+	}
+
+	/**
+	 * Map an RGB hex string to a grommunio Web standardIndex, if it is one of
+	 * the six standard flag colours.
+	 *
+	 * @param string $hex the RGB hex string
+	 * @return int|null the standardIndex, or null when not a standard colour
+	 */
+	public static function hexToStandardIndex($hex) {
+		$hex = strtolower($hex);
+		return isset(self::$standardIndexByHex[$hex]) ? self::$standardIndexByHex[$hex] : null;
+	}
+
+	/**
+	 * Convert a hex colour to an [r, g, b] triplet.
+	 *
+	 * @param string $hex hex string without a leading #
+	 * @return array|null [r, g, b], or null when malformed
+	 */
+	private static function hexToRgb($hex) {
+		if (strlen($hex) !== 6 || !ctype_xdigit($hex)) {
+			return null;
+		}
+
+		return [hexdec(substr($hex, 0, 2)), hexdec(substr($hex, 2, 2)), hexdec(substr($hex, 4, 2))];
+	}
+
+	/**
+	 * Generate a category GUID in Outlook's brace-wrapped upper-case form.
+	 *
+	 * @return string e.g. {AABBCCDD-EEFF-0011-2233-445566778899}
+	 */
+	private static function newGuid() {
+		$bytes = random_bytes(16);
+
+		return sprintf(
+			'{%s-%s-%s-%s-%s}',
+			strtoupper(bin2hex(substr($bytes, 0, 4))),
+			strtoupper(bin2hex(substr($bytes, 4, 2))),
+			strtoupper(bin2hex(substr($bytes, 6, 2))),
+			strtoupper(bin2hex(substr($bytes, 8, 2))),
+			strtoupper(bin2hex(substr($bytes, 10, 6)))
+		);
+	}
+
+	/**
+	 * Parse the category-list XML into a list of attribute maps (one per
+	 * <category>), keeping every attribute so nothing is lost on a round trip.
+	 *
+	 * @param string $xml the XML document
+	 * @return array a list of associative arrays of attribute name => value
+	 */
+	private function parseXml($xml) {
+		if (trim($xml) === '') {
+			return [];
+		}
+
+		$previous = libxml_use_internal_errors(true);
+		$doc = new DOMDocument();
+		$loaded = $doc->loadXML($xml);
+		libxml_clear_errors();
+		libxml_use_internal_errors($previous);
+		if (!$loaded) {
+			return [];
+		}
+
+		$nodes = [];
+		foreach ($doc->getElementsByTagName('category') as $element) {
+			$attributes = [];
+			foreach ($element->attributes as $attribute) {
+				// Normalise our own custom attributes to lower case so lookups
+				// are predictable; Outlook attributes keep their case.
+				$name = $attribute->name;
+				if (strpos($name, 'x-') === 0) {
+					$name = strtolower($name);
+				}
+				$attributes[$name] = $attribute->value;
+			}
+			$nodes[] = $attributes;
+		}
+
+		return $nodes;
+	}
+
+	/**
+	 * Build the category-list XML from a list of attribute maps.
+	 *
+	 * @param array $nodes a list of associative arrays of attribute name => value
+	 * @return string the XML document
+	 */
+	private function buildXml($nodes) {
+		$xml = '<?xml version="1.0"?>' . "\n";
+		$xml .= '<categories default="" lastSavedSession="00000000" lastSavedTime="' .
+			gmdate('Y-m-d\TH:i:s.000') . '" xmlns="CategoryList.xsd">';
+		foreach ($nodes as $node) {
+			$xml .= '<category';
+			foreach ($node as $name => $value) {
+				$xml .= ' ' . $name . '="' . htmlspecialchars((string) $value, ENT_QUOTES | ENT_XML1, 'UTF-8') . '"';
+			}
+			$xml .= '/>';
+		}
+		$xml .= '</categories>';
+
+		return $xml;
+	}
+}

--- a/server/includes/modules/class.categorylistmodule.php
+++ b/server/includes/modules/class.categorylistmodule.php
@@ -1,0 +1,100 @@
+<?php
+
+require_once __DIR__ . '/../core/class.categorylist.php';
+
+/**
+ * CategoryListModule.
+ *
+ * Serves the per-mailbox master category list (the Outlook-compatible list
+ * stored in each mailbox's Calendar folder, see {@link CategoryList}). Every
+ * request targets a single store via store_entryid; when none is given the
+ * logged-in user's own default store is used. This is what makes the list
+ * per-mailbox and shared: opening a shared mailbox reads that mailbox's list,
+ * not the current user's.
+ */
+class CategoryListModule extends Module {
+	/**
+	 * @param int   $id   unique id
+	 * @param array $data list of all actions
+	 */
+	public function __construct($id, $data) {
+		parent::__construct($id, $data);
+	}
+
+	/**
+	 * Execute all actions in the request.
+	 */
+	#[Override]
+	public function execute() {
+		foreach ($this->data as $actionType => $action) {
+			if (isset($actionType)) {
+				try {
+					match ($actionType) {
+						"list" => $this->listCategories($action),
+						"save" => $this->saveCategories($action),
+						default => $this->handleUnknownActionType($actionType),
+					};
+				}
+				catch (MAPIException $e) {
+					$this->processException($e, $actionType);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Resolve the store an action targets, defaulting to the user's own store.
+	 *
+	 * @param array $action the action data sent by the client
+	 * @return resource the message store to operate on
+	 */
+	private function getStoreForAction($action) {
+		$store = $this->getActionStore($action);
+		if (!$store) {
+			$store = $GLOBALS["mapisession"]->getDefaultMessageStore();
+		}
+
+		return $store;
+	}
+
+	/**
+	 * Return the master category list of the requested store.
+	 *
+	 * @param array $action the action data sent by the client
+	 */
+	private function listCategories($action) {
+		$store = $this->getStoreForAction($action);
+		$this->sendCategories("list", $store, new CategoryList($store));
+	}
+
+	/**
+	 * Store the master category list of the requested store, then return the
+	 * re-read list so the client picks up merged/preserved data.
+	 *
+	 * @param array $action the action data sent by the client
+	 */
+	private function saveCategories($action) {
+		$store = $this->getStoreForAction($action);
+		$categories = isset($action["categories"]) && is_array($action["categories"]) ? $action["categories"] : [];
+		$categoryList = new CategoryList($store);
+		$categoryList->setCategories($categories);
+		$this->sendCategories("update", $store, $categoryList);
+	}
+
+	/**
+	 * Send a category list to the client, tagged with the store it belongs to
+	 * (so the client can key its per-store cache).
+	 *
+	 * @param string       $actionType   the response action type
+	 * @param resource     $store        the store the list belongs to
+	 * @param CategoryList $categoryList the list accessor for that store
+	 */
+	private function sendCategories($actionType, $store, CategoryList $categoryList) {
+		$storeProps = mapi_getprops($store, [PR_ENTRYID]);
+		$this->addActionData($actionType, [
+			"store_entryid" => bin2hex((string) $storeProps[PR_ENTRYID]),
+			"categories" => $categoryList->getCategories(),
+		]);
+		$GLOBALS["bus"]->addData($this->getResponseData());
+	}
+}


### PR DESCRIPTION
## Summary
Makes the master category list (the set of category names + colours a user can pick from) **per-mailbox** instead of per-user, stored the same Outlook-compatible way Exchange uses. Each mailbox owns its list, so every user who opens that mailbox sees the same categories with the same colours, and the list interoperates with Outlook. Previously the list lived in the per-user WebApp settings, so it was not shared and did not match a mailbox's categories as seen in Outlook.

## How it works
The list is stored as a hidden associated (FAI) message of class `IPM.Configuration.CategoryList` in each mailbox's Calendar folder, holding the categories as XML in `PR_ROAMING_XMLSTREAM` — the exact item Outlook reads and writes. No backend change is required: gromox stores this FAI message and its properties generically.

- New `CategoryList` server class reads/writes that FAI, translating between grommunio Web's category shape and the Outlook XML, mapping colours to/from Outlook's palette index, and preserving each existing category's Outlook bookkeeping (guid, usageCount, keyboardShortcut, lastTimeUsed*) across edits by merging onto the stored list.
- New `categorylist` module serves per-store list/save, targeting a mailbox by `store_entryid`.
- Client `CategoryListManager` loads/caches/saves each open mailbox's list and prefetches them on hierarchy load (including shared mailboxes opened later). Category colours and names now resolve against the record's own mailbox list.

## Migration
On first load of a user's own mailbox with no stored list, it is seeded once from that user's existing per-user categories (which already include the defaults), so nobody loses their categories and every mailbox gets a usable starting list.

## Editing
The Manage Categories dialog edits the list of the mailbox the selected message lives in; apply, new, rename, recolour and pin write to that mailbox's list. Editing a mailbox the user has no write access to falls back harmlessly to read-only.

## Notes / limitations
- Colours are stored as Outlook palette indices (0–24), so a custom hex snaps to the nearest palette colour — inherent to Outlook interoperability.
- Reading or writing a shared mailbox's list requires access to its Calendar folder (where the list lives), matching Outlook's behaviour with limited shares.
- A few non-mail surfaces (calendar tooltip/appointment view, contact card, search grid, the unread-mail widget, and the standalone right-click rename) still resolve against the per-user list; these are a small follow-up.
