### PR TITLE
Fix HTTPS login: read __Secure- prefixed encryption-store-key cookie

### DIFF
--- a/server/includes/core/class.encryptionstore.php
+++ b/server/includes/core/class.encryptionstore.php
@@ -132,15 +132,17 @@ class EncryptionStore {
 	 * @return string
 	 */
 	private function getEncryptionKey() {
-		if (empty(EncryptionStore::$_encryptionKey)) {
-			// Try to find the encryption key in the cookie
-			if (isset($_COOKIE['encryption-store-key'])) {
-				EncryptionStore::$_encryptionKey = hex2bin((string) $_COOKIE['encryption-store-key']);
-			}
-		}
+        if (empty(EncryptionStore::$_encryptionKey)) {
+            if (isset($_COOKIE['__Secure-encryption-store-key'])) {
+                EncryptionStore::$_encryptionKey = hex2bin((string) $_COOKIE['__Secure-encryption-store-key']);
+            }
+            elseif (isset($_COOKIE['encryption-store-key'])) {
+                EncryptionStore::$_encryptionKey = hex2bin((string) $_COOKIE['encryption-store-key']);
+            }
+        }
 
-		return EncryptionStore::$_encryptionKey;
-	}
+        return EncryptionStore::$_encryptionKey;
+    }
 
 	/*
 	 * Remove expired entries from the $_SESSION


### PR DESCRIPTION
createEncryptionKey() sets the cookie with the __Secure- prefix when secure cookies are enabled, but getEncryptionKey() only read the unprefixed name, so on HTTPS the key was never found and fresh logins failed with MAPI_E_INVALID_PARAMETER. Read the prefixed cookie first, fall back to the unprefixed one.