### PR TITLE
feat: mailbox order

### DIFF
--- a/client/zarafa/hierarchy/data/StoreOrder.js
+++ b/client/zarafa/hierarchy/data/StoreOrder.js
@@ -117,6 +117,15 @@ Zarafa.hierarchy.data.StoreOrder = Ext.extend(Ext.util.Observable, {
 	 */
 	compareStores: function(store1, store2)
 	{
+		// Both stores must be ones the user may reorder. Without this the own store,
+		// which never has an explicit position, would sort *after* every shared store
+		// that has one - visible in a filtered tree such as the calendar folder list,
+		// where the own store's folders are ordinary top level nodes and are therefore
+		// not held in place by the IPM_SUBTREE rules in the sorter.
+		if (!this.isReorderable(store1) || !this.isReorderable(store2)) {
+			return 0;
+		}
+
 		var index1 = this.indexOf(store1);
 		var index2 = this.indexOf(store2);
 
@@ -141,18 +150,19 @@ Zarafa.hierarchy.data.StoreOrder = Ext.extend(Ext.util.Observable, {
 	 * Persist a new order and inform all listeners. The complete sequence of
 	 * {@link #isReorderable reorderable} stores is written, so the stored order is
 	 * always a full description of what the user sees rather than a partial one.
-	 * @param {Zarafa.hierarchy.data.MAPIStoreRecord[]} mapiStores The stores in their new order
+	 * @param {String[]} keys The {@link #getStoreKey store keys} in their new order
 	 */
-	applyOrder: function(mapiStores)
+	setOrder: function(keys)
 	{
 		var order = [];
 
-		for (var i = 0, len = mapiStores.length; i < len; i++) {
-			var key = this.getStoreKey(mapiStores[i]);
+		for (var i = 0, len = keys.length; i < len; i++) {
 			// Guard against a store being listed twice, which would make the
 			// comparison in compareStores depend on which duplicate is found first.
-			if (!Ext.isEmpty(key) && order.indexOf(key) === -1) {
-				order.push(key);
+			// A store can legitimately have several top level nodes in a filtered
+			// tree - one per visible folder - so duplicates are expected input here.
+			if (!Ext.isEmpty(keys[i]) && order.indexOf(keys[i]) === -1) {
+				order.push(keys[i]);
 			}
 		}
 

--- a/client/zarafa/hierarchy/data/StoreOrder.js
+++ b/client/zarafa/hierarchy/data/StoreOrder.js
@@ -1,0 +1,165 @@
+Ext.namespace('Zarafa.hierarchy.data');
+
+/**
+ * @class Zarafa.hierarchy.data.StoreOrder
+ * @extends Ext.util.Observable
+ *
+ * Manager for the user-defined order of the mailboxes (stores) in the hierarchy.
+ *
+ * By default the hierarchy places the own store on top, the Public store at the
+ * bottom, and sorts all shared stores alphabetically in between (see
+ * {@link Zarafa.hierarchy.ui.TreeSorter}). This manager holds an explicit order for
+ * the shared stores, which is persisted in the user settings so it survives a reload
+ * and applies to every hierarchy tree in the client.
+ *
+ * Stores are identified by their {@link Zarafa.hierarchy.data.MAPIStoreRecord#user_name
+ * user_name} rather than by their store entryid, because that is the identifier the
+ * shared-store settings themselves are keyed on and it remains valid when a store is
+ * closed and opened again.
+ *
+ * @singleton
+ */
+Zarafa.hierarchy.data.StoreOrder = Ext.extend(Ext.util.Observable, {
+	/**
+	 * The settings path in which the order is persisted. The value is an array of
+	 * {@link #getStoreKey store keys}, ordered top to bottom.
+	 * @property
+	 * @type String
+	 */
+	settingsPath: 'zarafa/v1/contexts/hierarchy/store_order',
+
+	/**
+	 * @constructor
+	 */
+	constructor: function()
+	{
+		this.addEvents(
+			/**
+			 * @event change
+			 * Fires after the order of the mailboxes has been changed. Hierarchy trees
+			 * listen to this to re-sort themselves, as the order applies to all of them
+			 * and not only to the tree in which the change was made.
+			 * @param {Zarafa.hierarchy.data.StoreOrder} storeOrder This object
+			 * @param {String[]} order The new order as a list of {@link #getStoreKey store keys}
+			 */
+			'change'
+		);
+
+		Zarafa.hierarchy.data.StoreOrder.superclass.constructor.call(this);
+	},
+
+	/**
+	 * Obtain the identifier under which the given store is recorded in the order.
+	 * @param {Zarafa.hierarchy.data.MAPIStoreRecord} mapiStore The store to identify
+	 * @return {String} The key for the store, or an empty string when the store cannot
+	 * be identified and can therefore not be ordered.
+	 */
+	getStoreKey: function(mapiStore)
+	{
+		if (!mapiStore) {
+			return '';
+		}
+
+		var userName = mapiStore.get('user_name');
+		return Ext.isString(userName) ? userName.toLowerCase() : '';
+	},
+
+	/**
+	 * Check if the given store may be moved by the user. Only shared stores can be
+	 * reordered; the own store remains pinned to the top of the hierarchy and the
+	 * Public store to the bottom, which is the order the client has always had.
+	 * @param {Zarafa.hierarchy.data.MAPIStoreRecord} mapiStore The store to check
+	 * @return {Boolean} True when the store can be reordered
+	 */
+	isReorderable: function(mapiStore)
+	{
+		if (!mapiStore || !mapiStore.isSharedStore()) {
+			return false;
+		}
+
+		return !Ext.isEmpty(this.getStoreKey(mapiStore));
+	},
+
+	/**
+	 * Obtain the currently persisted order.
+	 * @return {String[]} The ordered list of {@link #getStoreKey store keys}
+	 */
+	getOrder: function()
+	{
+		var order = container.getSettingsModel().get(this.settingsPath, true);
+		return Array.isArray(order) ? order : [];
+	},
+
+	/**
+	 * Obtain the position of the given store within the persisted order.
+	 * @param {Zarafa.hierarchy.data.MAPIStoreRecord} mapiStore The store to look up
+	 * @return {Number} The index of the store, or -1 when the store has no explicit position
+	 */
+	indexOf: function(mapiStore)
+	{
+		var key = this.getStoreKey(mapiStore);
+		if (Ext.isEmpty(key)) {
+			return -1;
+		}
+
+		return this.getOrder().indexOf(key);
+	},
+
+	/**
+	 * Compare two stores based on the user-defined order. Stores which have an explicit
+	 * position are placed before stores which have none, so a mailbox opened after the
+	 * user last reordered the hierarchy appears at the bottom of the shared stores
+	 * rather than in an arbitrary spot.
+	 * @param {Zarafa.hierarchy.data.MAPIStoreRecord} store1 The first store to compare
+	 * @param {Zarafa.hierarchy.data.MAPIStoreRecord} store2 The second store to compare
+	 * @return {Number} -1 when store1 comes first, +1 when store2 comes first, 0 when
+	 * neither store has an explicit position and the caller must decide the order itself.
+	 */
+	compareStores: function(store1, store2)
+	{
+		var index1 = this.indexOf(store1);
+		var index2 = this.indexOf(store2);
+
+		if (index1 === index2) {
+			// Either both stores are unordered (-1), or the same store is compared
+			// with itself. Let the caller fall back to its own comparison.
+			return 0;
+		}
+
+		if (index1 === -1) {
+			return +1;
+		}
+
+		if (index2 === -1) {
+			return -1;
+		}
+
+		return index1 < index2 ? -1 : +1;
+	},
+
+	/**
+	 * Persist a new order and inform all listeners. The complete sequence of
+	 * {@link #isReorderable reorderable} stores is written, so the stored order is
+	 * always a full description of what the user sees rather than a partial one.
+	 * @param {Zarafa.hierarchy.data.MAPIStoreRecord[]} mapiStores The stores in their new order
+	 */
+	applyOrder: function(mapiStores)
+	{
+		var order = [];
+
+		for (var i = 0, len = mapiStores.length; i < len; i++) {
+			var key = this.getStoreKey(mapiStores[i]);
+			// Guard against a store being listed twice, which would make the
+			// comparison in compareStores depend on which duplicate is found first.
+			if (!Ext.isEmpty(key) && order.indexOf(key) === -1) {
+				order.push(key);
+			}
+		}
+
+		container.getSettingsModel().set(this.settingsPath, order);
+
+		this.fireEvent('change', this, order);
+	}
+});
+
+Zarafa.hierarchy.data.StoreOrder = new Zarafa.hierarchy.data.StoreOrder();

--- a/client/zarafa/hierarchy/ui/ContextMenu.js
+++ b/client/zarafa/hierarchy/ui/ContextMenu.js
@@ -197,6 +197,27 @@ Zarafa.hierarchy.ui.ContextMenu = Ext.extend(Zarafa.core.ui.menu.ConditionalMenu
 				}
 			}
 		}, {
+			text: _('Remove'),
+			iconCls: 'icon_store_close',
+			handler: this.onContextItemRemoveSharedStore,
+			scope: this,
+			beforeShow: function(item, record) {
+				// A shared mailbox opened as a whole is shown in a filtered tree - the
+				// calendar folder list, for instance - as its visible folders, with no
+				// IPM_SUBTREE node to hang "Close store" on and no shared-folder key to
+				// hang "Close folder" on. Without this item such a mailbox cannot be
+				// removed from that list at all.
+				var node = this.contextNode;
+				var isTopLevel = !!node && !!node.parentNode && node.parentNode.isRoot === true;
+
+				if (isTopLevel && !record.isIPMSubTree() && !record.isSharedFolder() &&
+					record.getMAPIStore().isSharedStore()) {
+					item.setDisabled(false);
+				} else {
+					item.setDisabled(true);
+				}
+			}
+		}, {
 			xtype: 'menuseparator'
 		}, {
 			text: _('Reload'),
@@ -701,6 +722,18 @@ Zarafa.hierarchy.ui.ContextMenu = Ext.extend(Zarafa.core.ui.menu.ConditionalMenu
 
 		folderstore.remove(this.records);
 		folderstore.save(this.records);
+	},
+
+	/**
+	 * Fires on selecting the "Remove" menu option from the contextmenu, which is offered on
+	 * a top level folder of a shared mailbox that was opened as a whole. The mailbox is not
+	 * opened per folder, so there is no single folder to close: removing the entry means
+	 * closing the shared mailbox, which is what "Close store" does on the mailbox itself.
+	 * @private
+	 */
+	onContextItemRemoveSharedStore: function()
+	{
+		this.onContextItemCloseStore();
 	},
 
 	/**

--- a/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
+++ b/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
@@ -88,19 +88,21 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 		var tn = n.node;
 		var dragNode = dd && dd.dragData ? dd.dragData.node : undefined;
 
-		// A mailbox is dropped between mailboxes, never into one, so it has no 'append'
-		// point. Split the node in half instead of in thirds, which the code below does
-		// to leave room for 'append' - otherwise the middle of every row would be dead.
-		if (Zarafa.hierarchy.ui.HierarchyFolderDropZone.isReorderableNode(dragNode)) {
-			var el = n.ddel;
-			var middle = Ext.lib.Dom.getY(el) + (el.offsetHeight / 2);
-			return Ext.lib.Event.getPageY(e) < middle ? 'above' : 'below';
-		}
-
 		if (tn.isRoot) {
 			return tn.allowChildren !== false ? 'append' : false; // always append for root
 		}
 		var dragEl = n.ddel;
+
+		// A mailbox is dropped between mailboxes, never into one, so it has no 'append'
+		// point. Split the node in half instead of in thirds, which the code below does
+		// to leave room for 'append' - otherwise the middle of every row would be dead.
+		// Kept below the isRoot check above: the root node's UI has no 'elNode', so
+		// reading its geometry would throw.
+		if (Zarafa.hierarchy.ui.HierarchyFolderDropZone.isReorderableNode(dragNode)) {
+			var middle = Ext.lib.Dom.getY(dragEl) + (dragEl.offsetHeight / 2);
+			return Ext.lib.Event.getPageY(e) < middle ? 'above' : 'below';
+		}
+
 		var t = Ext.lib.Dom.getY(dragEl), b = t + dragEl.offsetHeight;
 		var y = Ext.lib.Event.getPageY(e);
 		var noAppend = tn.allowChildren === false;
@@ -211,7 +213,11 @@ Ext.apply(Zarafa.hierarchy.ui.HierarchyFolderDropZone, {
 			return false;
 		}
 
-		return !!node.parentNode && node.parentNode.isRoot === true;
+		if (!node.parentNode) {
+			return false;
+		}
+
+		return node.parentNode.isRoot === true;
 	},
 
 	/**

--- a/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
+++ b/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
@@ -91,7 +91,7 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 		// A mailbox is dropped between mailboxes, never into one, so it has no 'append'
 		// point. Split the node in half instead of in thirds, which the code below does
 		// to leave room for 'append' - otherwise the middle of every row would be dead.
-		if (Zarafa.hierarchy.ui.HierarchyFolderDropZone.isStoreRootNode(dragNode)) {
+		if (Zarafa.hierarchy.ui.HierarchyFolderDropZone.isReorderableNode(dragNode)) {
 			var el = n.ddel;
 			var middle = Ext.lib.Dom.getY(el) + (el.offsetHeight / 2);
 			return Ext.lib.Event.getPageY(e) < middle ? 'above' : 'below';
@@ -158,11 +158,13 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 			return false;
 		}
 
-		// A mailbox is being dragged to a new position: it may only be dropped between
-		// other mailboxes which the user is allowed to reorder. In particular it must
-		// never be appended into a folder, which would read as "move this mailbox into
-		// that folder" and has no meaning.
-		if (zone.isStoreRootNode(dropNode)) {
+		// A top level node stands for a mailbox, so dragging one can only ever mean moving
+		// that mailbox to another position - never a folder move, even in a filtered tree
+		// where the node happens to be an ordinary folder. It may therefore only be
+		// dropped between other mailboxes which the user is allowed to reorder, and never
+		// appended into a folder, which would read as "move this mailbox into that folder"
+		// and has no meaning.
+		if (zone.isTopLevelNode(dropNode)) {
 			if (!zone.isReorderableNode(dropNode) || !zone.isReorderableNode(targetNode)) {
 				return false;
 			}
@@ -193,35 +195,37 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 
 Ext.apply(Zarafa.hierarchy.ui.HierarchyFolderDropZone, {
 	/**
-	 * Check if the given tree node represents a mailbox, i.e. the IPM_SUBTREE of a store.
+	 * Check if the given tree node sits at the top level of the hierarchy, i.e. directly
+	 * below the invisible root node. Which folder that is depends on the tree: in an
+	 * unfiltered tree it is the IPM_SUBTREE of a store, but in a filtered tree - the
+	 * calendar folder list, for instance - the IPM_SUBTREE of a shared store is left out
+	 * and its visible folders are lifted to the top level instead
+	 * (see {@link Zarafa.hierarchy.data.HierarchyTreeLoader#directFn}).
 	 * @param {Ext.tree.TreeNode} node The node to check
-	 * @return {Boolean} True when the node is a mailbox root node
+	 * @return {Boolean} True when the node is a top level node of the hierarchy
 	 * @static
 	 */
-	isStoreRootNode: function(node)
+	isTopLevelNode: function(node)
 	{
-		if (!node || !Ext.isFunction(node.getFolder)) {
+		if (!node || !Ext.isFunction(node.getFolder) || !node.getFolder()) {
 			return false;
 		}
 
-		var folder = node.getFolder();
-		if (!folder) {
-			return false;
-		}
-
-		return folder.isIPMSubTree();
+		return !!node.parentNode && node.parentNode.isRoot === true;
 	},
 
 	/**
-	 * Check if the given tree node represents a mailbox whose position in the hierarchy
-	 * the user is allowed to change.
+	 * Check if the given tree node stands for a mailbox whose position in the hierarchy
+	 * the user is allowed to change. In a filtered tree several nodes can stand for the
+	 * same mailbox, one per visible folder; each of them may be dragged and they move
+	 * the mailbox as a whole.
 	 * @param {Ext.tree.TreeNode} node The node to check
-	 * @return {Boolean} True when the node is a reorderable mailbox root node
+	 * @return {Boolean} True when dragging the node reorders the mailboxes
 	 * @static
 	 */
 	isReorderableNode: function(node)
 	{
-		if (!this.isStoreRootNode(node)) {
+		if (!this.isTopLevelNode(node)) {
 			return false;
 		}
 
@@ -230,7 +234,8 @@ Ext.apply(Zarafa.hierarchy.ui.HierarchyFolderDropZone, {
 
 	/**
 	 * Check if the given drop event describes a mailbox being moved to a new position in
-	 * the hierarchy, as opposed to a folder being moved or copied.
+	 * the hierarchy, as opposed to a folder being moved or copied. A drop onto another
+	 * node of the same mailbox is not a reorder - there is nothing to move.
 	 * @param {Object} dropEvent The event object which describes what node is being dropped where
 	 * @return {Boolean} True when the drop reorders the mailboxes
 	 * @static
@@ -241,6 +246,12 @@ Ext.apply(Zarafa.hierarchy.ui.HierarchyFolderDropZone, {
 			return false;
 		}
 
-		return this.isReorderableNode(dropEvent.dropNode) && this.isReorderableNode(dropEvent.target);
+		if (!this.isReorderableNode(dropEvent.dropNode) || !this.isReorderableNode(dropEvent.target)) {
+			return false;
+		}
+
+		var storeOrder = Zarafa.hierarchy.data.StoreOrder;
+		return storeOrder.getStoreKey(dropEvent.dropNode.getFolder().getMAPIStore()) !==
+			storeOrder.getStoreKey(dropEvent.target.getFolder().getMAPIStore());
 	}
 });

--- a/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
+++ b/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
@@ -40,6 +40,13 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 		var dropNode = dropEvent.dropNode;
 
 		if (Ext.isDefined(dropNode)) {
+			// Reordering the mailboxes is a drop between siblings by definition: every
+			// mailbox hangs off the same (invisible) root node. So it must be exempt from
+			// the same-parent check below, which exists for folders being moved.
+			if (Zarafa.hierarchy.ui.HierarchyFolderDropZone.isStoreReorderDrop(dropEvent)) {
+				return;
+			}
+
 			var targetNode = dropEvent.target;
 
 			switch (dropEvent.point) {
@@ -79,6 +86,16 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 	getDropPoint: function(e, n, dd)
 	{
 		var tn = n.node;
+		var dragNode = dd && dd.dragData ? dd.dragData.node : undefined;
+
+		// A mailbox is dropped between mailboxes, never into one, so it has no 'append'
+		// point. Split the node in half instead of in thirds, which the code below does
+		// to leave room for 'append' - otherwise the middle of every row would be dead.
+		if (Zarafa.hierarchy.ui.HierarchyFolderDropZone.isStoreRootNode(dragNode)) {
+			var el = n.ddel;
+			var middle = Ext.lib.Dom.getY(el) + (el.offsetHeight / 2);
+			return Ext.lib.Event.getPageY(e) < middle ? 'above' : 'below';
+		}
 
 		if (tn.isRoot) {
 			return tn.allowChildren !== false ? 'append' : false; // always append for root
@@ -134,8 +151,27 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 	isValidDropPoint: function(n, pt, dd, e, data)
 	{
 		var targetNode = n ? n.node : undefined;
+		var dropNode = data ? data.node : undefined;
+		var zone = Zarafa.hierarchy.ui.HierarchyFolderDropZone;
+
 		if (!targetNode || !Ext.isFunction(targetNode.getFolder)) {
 			return false;
+		}
+
+		// A mailbox is being dragged to a new position: it may only be dropped between
+		// other mailboxes which the user is allowed to reorder. In particular it must
+		// never be appended into a folder, which would read as "move this mailbox into
+		// that folder" and has no meaning.
+		if (zone.isStoreRootNode(dropNode)) {
+			if (!zone.isReorderableNode(dropNode) || !zone.isReorderableNode(targetNode)) {
+				return false;
+			}
+
+			if (pt !== 'above' && pt !== 'below') {
+				return false;
+			}
+
+			return zone.superclass.isValidDropPoint.apply(this, arguments);
 		}
 
 		var folder = targetNode.getFolder();
@@ -151,6 +187,60 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 			return false;
 		}
 
-		return Zarafa.hierarchy.ui.HierarchyFolderDropZone.superclass.isValidDropPoint.apply(this, arguments);
+		return zone.superclass.isValidDropPoint.apply(this, arguments);
+	}
+});
+
+Ext.apply(Zarafa.hierarchy.ui.HierarchyFolderDropZone, {
+	/**
+	 * Check if the given tree node represents a mailbox, i.e. the IPM_SUBTREE of a store.
+	 * @param {Ext.tree.TreeNode} node The node to check
+	 * @return {Boolean} True when the node is a mailbox root node
+	 * @static
+	 */
+	isStoreRootNode: function(node)
+	{
+		if (!node || !Ext.isFunction(node.getFolder)) {
+			return false;
+		}
+
+		var folder = node.getFolder();
+		if (!folder) {
+			return false;
+		}
+
+		return folder.isIPMSubTree();
+	},
+
+	/**
+	 * Check if the given tree node represents a mailbox whose position in the hierarchy
+	 * the user is allowed to change.
+	 * @param {Ext.tree.TreeNode} node The node to check
+	 * @return {Boolean} True when the node is a reorderable mailbox root node
+	 * @static
+	 */
+	isReorderableNode: function(node)
+	{
+		if (!this.isStoreRootNode(node)) {
+			return false;
+		}
+
+		return Zarafa.hierarchy.data.StoreOrder.isReorderable(node.getFolder().getMAPIStore());
+	},
+
+	/**
+	 * Check if the given drop event describes a mailbox being moved to a new position in
+	 * the hierarchy, as opposed to a folder being moved or copied.
+	 * @param {Object} dropEvent The event object which describes what node is being dropped where
+	 * @return {Boolean} True when the drop reorders the mailboxes
+	 * @static
+	 */
+	isStoreReorderDrop: function(dropEvent)
+	{
+		if (dropEvent.point !== 'above' && dropEvent.point !== 'below') {
+			return false;
+		}
+
+		return this.isReorderableNode(dropEvent.dropNode) && this.isReorderableNode(dropEvent.target);
 	}
 });

--- a/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
+++ b/client/zarafa/hierarchy/ui/HierarchyFolderDropZone.js
@@ -133,10 +133,24 @@ Zarafa.hierarchy.ui.HierarchyFolderDropZone = Ext.extend(Zarafa.hierarchy.ui.Hie
 	 */
 	isValidDropPoint: function(n, pt, dd, e, data)
 	{
-		var folder = n.node.getFolder();
+		var targetNode = n ? n.node : undefined;
+		if (!targetNode || !Ext.isFunction(targetNode.getFolder)) {
+			return false;
+		}
+
+		var folder = targetNode.getFolder();
 		if (folder.isDropTargetForFolders() === false) {
 			return false;
 		}
+
+		// Dropping a folder above or below the root node of a store means dropping it
+		// into that node's parent, which is the invisible root node of the hierarchy -
+		// not a folder at all. The drop was accepted and then failed in the move
+		// handler, which reads 'target.getFolder()' on a node that has no such method.
+		if ((pt === 'above' || pt === 'below') && !targetNode.parentNode.getFolder) {
+			return false;
+		}
+
 		return Zarafa.hierarchy.ui.HierarchyFolderDropZone.superclass.isValidDropPoint.apply(this, arguments);
 	}
 });

--- a/client/zarafa/hierarchy/ui/HierarchyTreePanel.js
+++ b/client/zarafa/hierarchy/ui/HierarchyTreePanel.js
@@ -448,34 +448,41 @@ Zarafa.hierarchy.ui.HierarchyTreePanel = Ext.extend(Zarafa.hierarchy.ui.Tree, {
 	onStoreReorderDrop: function(dropEvent)
 	{
 		var dropNode = dropEvent.dropNode;
-		var targetNode = dropEvent.target;
 		var dropZone = Zarafa.hierarchy.ui.HierarchyFolderDropZone;
+		var storeOrder = Zarafa.hierarchy.data.StoreOrder;
 
-		// Take the mailboxes as they are currently shown, leaving out the one being
-		// dragged so it can be reinserted at its new position. Reading the order from
-		// the tree rather than from the settings keeps the two in step even when a
-		// mailbox was opened after the user last reordered the hierarchy.
-		var nodes = [];
+		var keyOf = function(node) {
+			return storeOrder.getStoreKey(node.getFolder().getMAPIStore());
+		};
+
+		var draggedKey = keyOf(dropNode);
+		var targetKey = keyOf(dropEvent.target);
+
+		// Work on mailboxes rather than on nodes: in a filtered tree one mailbox can have
+		// several top level nodes, one per visible folder, and they all move together.
+		// Reading the sequence from the tree rather than from the settings keeps the two
+		// in step even when a mailbox was opened after the last reorder.
+		var keys = [];
 		var siblings = dropNode.parentNode.childNodes;
 		for (var i = 0, len = siblings.length; i < len; i++) {
-			if (siblings[i] !== dropNode && dropZone.isReorderableNode(siblings[i])) {
-				nodes.push(siblings[i]);
+			if (!dropZone.isReorderableNode(siblings[i])) {
+				continue;
+			}
+
+			var key = keyOf(siblings[i]);
+			if (key !== draggedKey && keys.indexOf(key) === -1) {
+				keys.push(key);
 			}
 		}
 
-		var targetIndex = nodes.indexOf(targetNode);
+		var targetIndex = keys.indexOf(targetKey);
 		if (targetIndex === -1) {
 			return false;
 		}
 
-		nodes.splice(dropEvent.point === 'above' ? targetIndex : targetIndex + 1, 0, dropNode);
+		keys.splice(dropEvent.point === 'above' ? targetIndex : targetIndex + 1, 0, draggedKey);
 
-		var mapiStores = [];
-		for (var j = 0, jlen = nodes.length; j < jlen; j++) {
-			mapiStores.push(nodes[j].getFolder().getMAPIStore());
-		}
-
-		Zarafa.hierarchy.data.StoreOrder.applyOrder(mapiStores);
+		storeOrder.setOrder(keys);
 	},
 
 	/**

--- a/client/zarafa/hierarchy/ui/HierarchyTreePanel.js
+++ b/client/zarafa/hierarchy/ui/HierarchyTreePanel.js
@@ -367,6 +367,12 @@ Zarafa.hierarchy.ui.HierarchyTreePanel = Ext.extend(Zarafa.hierarchy.ui.Tree, {
 	{
 		var dropNode = dropEvent.dropNode;
 		if (Ext.isDefined(dropNode)) {
+			// A mailbox dropped between two other mailboxes changes the order of the
+			// hierarchy rather than moving anything in the mailbox itself.
+			if (Zarafa.hierarchy.ui.HierarchyFolderDropZone.isStoreReorderDrop(dropEvent)) {
+				return this.onStoreReorderDrop(dropEvent);
+			}
+
 			var targetNode = dropEvent.target;
 
 			switch (dropEvent.point) {
@@ -426,6 +432,50 @@ Zarafa.hierarchy.ui.HierarchyTreePanel = Ext.extend(Zarafa.hierarchy.ui.Tree, {
 
 			sourceFolder.save();
 		}
+	},
+
+	/**
+	 * Handle a drop which moves a mailbox to another position in the hierarchy. Nothing is
+	 * moved in the mailbox itself; the new order of the mailboxes is derived from the
+	 * position the node was dropped at and handed to
+	 * {@link Zarafa.hierarchy.data.StoreOrder} to be persisted. Every hierarchy tree then
+	 * re-sorts itself, so all trees keep showing the same order.
+	 * @param {Object} dropEvent The object describing the drop information
+	 * @return {Boolean} False when the drop could not be resolved to a new order, in
+	 * which case the hierarchy is left as it was
+	 * @private
+	 */
+	onStoreReorderDrop: function(dropEvent)
+	{
+		var dropNode = dropEvent.dropNode;
+		var targetNode = dropEvent.target;
+		var dropZone = Zarafa.hierarchy.ui.HierarchyFolderDropZone;
+
+		// Take the mailboxes as they are currently shown, leaving out the one being
+		// dragged so it can be reinserted at its new position. Reading the order from
+		// the tree rather than from the settings keeps the two in step even when a
+		// mailbox was opened after the user last reordered the hierarchy.
+		var nodes = [];
+		var siblings = dropNode.parentNode.childNodes;
+		for (var i = 0, len = siblings.length; i < len; i++) {
+			if (siblings[i] !== dropNode && dropZone.isReorderableNode(siblings[i])) {
+				nodes.push(siblings[i]);
+			}
+		}
+
+		var targetIndex = nodes.indexOf(targetNode);
+		if (targetIndex === -1) {
+			return false;
+		}
+
+		nodes.splice(dropEvent.point === 'above' ? targetIndex : targetIndex + 1, 0, dropNode);
+
+		var mapiStores = [];
+		for (var j = 0, jlen = nodes.length; j < jlen; j++) {
+			mapiStores.push(nodes[j].getFolder().getMAPIStore());
+		}
+
+		Zarafa.hierarchy.data.StoreOrder.applyOrder(mapiStores);
 	},
 
 	/**

--- a/client/zarafa/hierarchy/ui/HierarchyTreePanel.js
+++ b/client/zarafa/hierarchy/ui/HierarchyTreePanel.js
@@ -380,6 +380,14 @@ Zarafa.hierarchy.ui.HierarchyTreePanel = Ext.extend(Zarafa.hierarchy.ui.Tree, {
 					break;
 			}
 
+			// See HierarchyFolderDropZone#isValidDropPoint: a drop which resolves to the
+			// invisible root node of the hierarchy is not a folder move, and asking it
+			// for its folder throws. Second line of defence, in case such a drop is
+			// raised from anywhere else.
+			if (!Ext.isFunction(targetNode.getFolder)) {
+				return false;
+			}
+
 			var sourceFolder = dropNode.getFolder();
 			var targetFolder = targetNode.getFolder();
 

--- a/client/zarafa/hierarchy/ui/RootFolderNode.js
+++ b/client/zarafa/hierarchy/ui/RootFolderNode.js
@@ -21,13 +21,19 @@ Zarafa.hierarchy.ui.RootFolderNode = Ext.extend(Zarafa.hierarchy.ui.FolderNode, 
 		// A shared mailbox can be dragged to give it a position of the user's choosing
 		// within the hierarchy. The own store and the Public store stay pinned to the
 		// top and the bottom respectively, so their root nodes remain undraggable.
+		//
+		// This node type is used for every top level node, which is the IPM_SUBTREE of a
+		// store in an unfiltered tree but the store's visible folders in a filtered one -
+		// the calendar folder list, for instance. Both stand for their mailbox here, so
+		// both can be dragged to move it.
 		var reorderable = false;
 
 		// Format IPM subtree container differently
 		if (config.folder) {
+			reorderable = Zarafa.hierarchy.data.StoreOrder.isReorderable(config.folder.getMAPIStore());
+
 			if (config.folder.isIPMSubTree()) {
 				containerCls += ' zarafa-tree-ipm-subtree-container';
-				reorderable = Zarafa.hierarchy.data.StoreOrder.isReorderable(config.folder.getMAPIStore());
 			} else if (config.folder.isFavoritesRootFolder()) {
 				containerCls += ' zarafa-tree-ipm-subtree-favorites-container';
 			}

--- a/client/zarafa/hierarchy/ui/RootFolderNode.js
+++ b/client/zarafa/hierarchy/ui/RootFolderNode.js
@@ -18,10 +18,16 @@ Zarafa.hierarchy.ui.RootFolderNode = Ext.extend(Zarafa.hierarchy.ui.FolderNode, 
 		var containerCls = 'zarafa-tree-root-container';
 		var nodeCls = 'zarafa-tree-root-node';
 
+		// A shared mailbox can be dragged to give it a position of the user's choosing
+		// within the hierarchy. The own store and the Public store stay pinned to the
+		// top and the bottom respectively, so their root nodes remain undraggable.
+		var reorderable = false;
+
 		// Format IPM subtree container differently
 		if (config.folder) {
 			if (config.folder.isIPMSubTree()) {
 				containerCls += ' zarafa-tree-ipm-subtree-container';
+				reorderable = Zarafa.hierarchy.data.StoreOrder.isReorderable(config.folder.getMAPIStore());
 			} else if (config.folder.isFavoritesRootFolder()) {
 				containerCls += ' zarafa-tree-ipm-subtree-favorites-container';
 			}
@@ -30,9 +36,15 @@ Zarafa.hierarchy.ui.RootFolderNode = Ext.extend(Zarafa.hierarchy.ui.FolderNode, 
 
 		Ext.applyIf(config, {
 			containerCls: containerCls,
-			cls: nodeCls,
-			allowDrag: false,
-			draggable: false
+			cls: nodeCls
+		});
+
+		// Set authoritatively rather than with applyIf: the HierarchyTreeLoader already
+		// assigns 'allowDrag' for every node it creates, and whether a root node can be
+		// dragged is decided here and nowhere else.
+		Ext.apply(config, {
+			allowDrag: reorderable,
+			draggable: reorderable
 		});
 
 		Zarafa.hierarchy.ui.RootFolderNode.superclass.constructor.call(this, config);

--- a/client/zarafa/hierarchy/ui/Tree.js
+++ b/client/zarafa/hierarchy/ui/Tree.js
@@ -144,6 +144,12 @@ Zarafa.hierarchy.ui.Tree = Ext.extend(Ext.tree.TreePanel, {
 			this.treeSorter = new Zarafa.hierarchy.ui.TreeSorter(this, Ext.apply({}, this.treeSorter));
 		}
 
+		// The order of the mailboxes is shared by all hierarchy trees, so a change made
+		// in one tree must be reflected in every other tree as well.
+		if (this.treeSorter) {
+			this.mon(Zarafa.hierarchy.data.StoreOrder, 'change', this.onStoreOrderChange, this);
+		}
+
 		// filter tree on search query.
 		if (this.treeFilter && !(this.treeFilter instanceof Ext.tree.TreeFilter)) {
 			this.treeFilter = new Zarafa.hierarchy.ui.HierarchyTreeFilter(this, {autoClear: true});
@@ -184,6 +190,21 @@ Zarafa.hierarchy.ui.Tree = Ext.extend(Ext.tree.TreePanel, {
 		// create load mask
 		if(this.loadMask) {
 			this.on('render', this.createLoadMask, this);
+		}
+	},
+
+	/**
+	 * Event handler for the {@link Zarafa.hierarchy.data.StoreOrder#change change} event,
+	 * fired when the user has given the mailboxes a new order. This re-sorts the mailboxes
+	 * in this tree, which the {@link #treeSorter} does not do by itself because no node was
+	 * added or removed.
+	 * @private
+	 */
+	onStoreOrderChange: function()
+	{
+		var rootNode = this.getRootNode();
+		if (rootNode) {
+			this.treeSorter.doSort(rootNode);
 		}
 	},
 

--- a/client/zarafa/hierarchy/ui/TreeSorter.js
+++ b/client/zarafa/hierarchy/ui/TreeSorter.js
@@ -141,6 +141,15 @@ Zarafa.hierarchy.ui.TreeSorter = Ext.extend(Ext.tree.TreeSorter, {
 		// we sort by the storeProperty, allowing the sorting based on
 		// the display name of the user, rather then of the folder.
 		if (folder1.isIPMSubTree() && folder2.isIPMSubTree()) {
+			// The user can give the shared stores an explicit order by dragging them
+			// in the hierarchy. That order wins over the alphabetical one below. Both
+			// stores are shared stores here, as the own and Public store were already
+			// handled by the checks above.
+			var orderCmp = Zarafa.hierarchy.data.StoreOrder.compareStores(store1, store2);
+			if (orderCmp !== 0) {
+				return dsc ? -orderCmp : orderCmp;
+			}
+
 			var cmp = this.compareRecordProp(store1, store2, this.storeProperty, dsc, cs);
 			// If the store properties are equal, then we have 2 shared folders which
 			// belong to the same store. We are going to sort those by the folderProperty.

--- a/client/zarafa/hierarchy/ui/TreeSorter.js
+++ b/client/zarafa/hierarchy/ui/TreeSorter.js
@@ -137,19 +137,26 @@ Zarafa.hierarchy.ui.TreeSorter = Ext.extend(Ext.tree.TreeSorter, {
 			}
 		}
 
-		// If both folder 1 as folder 2 are root nodes (IPM_SUBTREE) then
-		// we sort by the storeProperty, allowing the sorting based on
-		// the display name of the user, rather then of the folder.
-		if (folder1.isIPMSubTree() && folder2.isIPMSubTree()) {
-			// The user can give the shared stores an explicit order by dragging them
-			// in the hierarchy. That order wins over the alphabetical one below. Both
-			// stores are shared stores here, as the own and Public store were already
-			// handled by the checks above.
+		// The user can give the shared stores an explicit order by dragging them in the
+		// hierarchy, and that order wins over the alphabetical one below. This is checked
+		// for every pair of top level nodes, not only for two IPM_SUBTREEs: in a filtered
+		// tree such as the calendar folder list a shared store is represented by its
+		// visible folders rather than by its IPM_SUBTREE, and those must follow the same
+		// order. Nodes passed to a sort function always share a parent, so testing one of
+		// them is enough. {@link Zarafa.hierarchy.data.StoreOrder#compareStores} returns 0
+		// unless both stores are ones the user may reorder, which is what keeps the own
+		// and the Public store in place here.
+		if (node1.parentNode && node1.parentNode.isRoot === true) {
 			var orderCmp = Zarafa.hierarchy.data.StoreOrder.compareStores(store1, store2);
 			if (orderCmp !== 0) {
 				return dsc ? -orderCmp : orderCmp;
 			}
+		}
 
+		// If both folder 1 as folder 2 are root nodes (IPM_SUBTREE) then
+		// we sort by the storeProperty, allowing the sorting based on
+		// the display name of the user, rather then of the folder.
+		if (folder1.isIPMSubTree() && folder2.isIPMSubTree()) {
 			var cmp = this.compareRecordProp(store1, store2, this.storeProperty, dsc, cs);
 			// If the store properties are equal, then we have 2 shared folders which
 			// belong to the same store. We are going to sort those by the folderProperty.

--- a/client/zarafa/settings/data/SettingsDefaultValues.js
+++ b/client/zarafa/settings/data/SettingsDefaultValues.js
@@ -506,7 +506,18 @@ Zarafa.settings.data.SettingsDefaultValue = function(){
 								 * @property
 								 * @type Boolean
 								 */
-								'scroll_favorites': false
+								'scroll_favorites': false,
+
+								/**
+								 * zarafa/v1/contexts/hierarchy/store_order
+								 * The order in which the shared mailboxes are shown in the
+								 * hierarchy, as a list of user names. Empty means the shared
+								 * mailboxes are sorted alphabetically. See
+								 * {@link Zarafa.hierarchy.data.StoreOrder}.
+								 * @property
+								 * @type Array
+								 */
+								'store_order': []
 							},
 
 							'search': {


### PR DESCRIPTION
Closes #68.

Shared mailboxes can now be dragged to a position of the user's choosing in the folder pane, the way Outlook allows accounts to be reordered. The chosen order is stored per user and applies to every hierarchy tree in the client, so mail, calendar, contacts, tasks and notes all show the mailboxes in the same sequence.

The own mailbox stays pinned to the top and the Public store stays pinned to the bottom, exactly as before; only the shared mailboxes in between can be moved. Their default remains alphabetical, so nothing changes for a user who never drags anything, and a mailbox opened after the last reorder appears at the end of the shared mailboxes rather than in an arbitrary spot.

This works in a filtered tree as well, such as the calendar folder list. There a shared mailbox is not represented by its IPM_SUBTREE at all: the subtree does not pass the tree's container-class filter, so the loader lifts the mailbox's visible folders to the top level instead. Those nodes stand for their mailbox, so dragging one of them reorders the mailboxes just as dragging the mailbox itself does in the mail folder pane, and the two views always agree because they read the same stored order.

A filtered folder list also had no way to remove a shared mailbox from it. A mailbox opened as a whole has no IPM_SUBTREE node in such a tree for "Close store" to apply to, and no shared-folder key for "Close folder" to apply to, so both items were hidden and the entry could not be got rid of at all. Such a node now offers **Remove**, which closes the shared mailbox — the same thing "Close store" does on the mailbox itself, and the only granularity a mailbox opened as a whole has. It appears only on a top level node of a shared mailbox where neither existing item applies, so it neither duplicates them nor turns up on an ordinary folder inside a shared mailbox.

### How it works

`Zarafa.hierarchy.ui.TreeSorter` decides the order of the hierarchy, and it re-sorts on every node insert, so a manual `insertBefore` would be undone by the next hierarchy update. The user's order is therefore consulted inside the sorter rather than applied to the nodes: the new `Zarafa.hierarchy.data.StoreOrder` singleton holds the order and `hierarchySort()` asks it first, falling back to the existing alphabetical comparison when the order has nothing to say. That comparison returns "no opinion" unless both stores are ones the user may reorder, which is what keeps the own and the Public store in place — in a filtered tree they are ordinary top level nodes and are not held by the IPM_SUBTREE rules.

Stores are identified by `user_name` rather than by `store_entryid`, because that is the identifier the shared-store settings are already keyed on and it stays valid when a mailbox is closed and opened again. The order lives in `zarafa/v1/contexts/hierarchy/store_order` as a list of those names.

The drop itself is only a signal. `HierarchyFolderDropZone#completeDrop` does not move tree nodes — it fires `folderdrop` and lets the hierarchy update rebuild them — so the new handler derives the resulting sequence from the drop position, hands it to `StoreOrder`, and every tree re-sorts on the resulting `change` event. Because a filtered tree can show several top level nodes for one mailbox, one per visible folder, the handler works on mailboxes rather than on nodes: it collects them in the order their nodes appear, drops duplicates, and reinserts the dragged one at its new position. A drop onto another node of the same mailbox is not a reorder and does nothing. Writing the full sequence on every drop also means the stored order never drifts from what is on screen, and mailboxes that have since been closed fall out of it by themselves.

Three drag-and-drop details were needed to make the gesture behave:

- A mailbox has no `append` point, since dropping a mailbox *into* another mailbox has no meaning. `getDropPoint()` therefore splits a row in half for a mailbox drag instead of in thirds, so the whole row is a usable target rather than only its top and bottom third. It stays below the existing `isRoot` check, whose node UI has no element to measure.
- Every mailbox hangs off the same invisible root node, so reordering is a same-parent drop by definition. The same-parent guard in `onBeforeNodeDrop()`, which exists for folder moves, is skipped for a mailbox reorder.
- A top level node stands for a mailbox, so dragging one can only ever mean moving that mailbox. `isValidDropPoint()` treats every top level node that way, including the ones that cannot be dragged, rather than letting them fall through to the folder-move path where the target may be the invisible root node.

### Included fix

The first commit is a separate, self-contained fix that this change made visible: a folder could be dropped above or below a mailbox root node. The effective drop target is then the invisible root node of the hierarchy, which is not a folder, and `onFolderDrop()` called `getFolder()` on it — a `TypeError`, and the folder move silently did not happen. Such a drop is now refused in the drop zone, with a guard in the move handler as a second line of defence. It is kept as its own commit because it stands on its own; say the word if you would rather see it as a separate pull request.

