### PR TITLE
fix: honour the user's language setting

### DIFF
--- a/server/includes/core/class.language.php
+++ b/server/includes/core/class.language.php
@@ -4,6 +4,10 @@
  * Language handling class.
  */
 class Language {
+	// Key and size of the shared memory segment the parsed translations live in.
+	private const CACHE_KEY = 0x950412DE;
+	private const CACHE_SIZE = 16 * 1024 * 1024;
+
 	private $languages = ["en_US.UTF-8" => "English"];
 	private $lang;
 	private $loaded = false;
@@ -286,36 +290,78 @@ class Language {
 	}
 
 	public function getTranslations() {
-		$memid = @shm_attach(0x950412DE, 16 * 1024 * 1024, 0644);
+		$selected_lang = $this->getSelected();
+		$memid = @shm_attach(self::CACHE_KEY, self::CACHE_SIZE, 0644);
 		if ($memid && @shm_has_var($memid, 0)) {
 			$cache_table = @shm_get_var($memid, 0);
-			$selected_lang = $this->getSelected();
-			if (empty($cache_table) || empty($cache_table[$selected_lang])) {
-				@shm_remove_var($memid, 0);
+			if (is_array($cache_table) && !empty($cache_table)) {
+				if (!empty($cache_table[$selected_lang])) {
+					$translations = @shm_get_var($memid, $cache_table[$selected_lang]);
+					if (!empty($translations)) {
+						@shm_detach($memid);
+
+						return $translations;
+					}
+
+					/*
+					 * The table promises a payload the segment does not hold, so the
+					 * write behind it failed unnoticed - running out of room in the
+					 * segment does that. Dropping only the table would leave every
+					 * payload allocated, so the rebuild would run out of room again
+					 * and again while still advertising its entries, and this language
+					 * would stay untranslated until the segment is removed by hand.
+					 */
+					$memid = $this->resetCache($memid);
+
+					return $this->buildTranslations($memid);
+				}
+
+				/*
+				 * A usable table that simply does not list this language. Read it from
+				 * disk rather than rebuilding: a rebuild would write a second copy of
+				 * every other language into a segment that already holds them.
+				 */
 				@shm_detach($memid);
 
-				return ['grommunio_web' => []];
+				return $this->selectedTranslations($this->parseLanguage($selected_lang));
 			}
-			$translation_id = $cache_table[$selected_lang];
-			if (empty($translation_id)) {
-				@shm_remove_var($memid, 0);
-				@shm_detach($memid);
-
-				return ['grommunio_web' => []];
-			}
-			$translations = @shm_get_var($memid, $translation_id);
-			if (empty($translations)) {
-				@shm_remove_var($memid, 0);
-				@shm_detach($memid);
-
-				return ['grommunio_web' => []];
-			}
-			@shm_detach($memid);
-
-			return $translations;
+			// The table itself is unusable, for instance left behind by another PHP
+			// version, whose serialized data this one cannot read back.
+			$memid = $this->resetCache($memid);
 		}
+
+		return $this->buildTranslations($memid);
+	}
+
+	/**
+	 * Discard the translation cache in its entirety and start a new one.
+	 *
+	 * shm_remove_var() frees a single variable, which is not enough once the segment
+	 * is in a state the code cannot read: the payloads stay allocated and the next
+	 * rebuild has nowhere to put its own. Removing the segment releases everything.
+	 *
+	 * @param resource|SysvSharedMemory $memid the segment to discard
+	 *
+	 * @return bool|resource|SysvSharedMemory a fresh segment, or false without one
+	 */
+	private function resetCache($memid) {
+		@shm_remove($memid);
+		@shm_detach($memid);
+
+		return @shm_attach(self::CACHE_KEY, self::CACHE_SIZE, 0644);
+	}
+
+	/**
+	 * Read every installed language from disk, caching what fits in the segment.
+	 *
+	 * @param bool|resource|SysvSharedMemory $memid the segment to fill, or false to skip caching
+	 *
+	 * @return array the translations for the selected language
+	 */
+	private function buildTranslations($memid) {
 		$handle = opendir(LANGUAGE_DIR);
-		if ($handle == false) {
+		if ($handle === false) {
+			error_log(sprintf("Cannot read translations from '%s'", LANGUAGE_DIR));
 			if ($memid) {
 				@shm_detach($memid);
 			}
@@ -324,45 +370,85 @@ class Language {
 		}
 		$last_id = 1;
 		$cache_table = [];
+		$ret_val = false;
 		while (false !== ($entry = readdir($handle))) {
 			if (strcmp($entry, ".") == 0 ||
 				strcmp($entry, "..") == 0) {
 				continue;
 			}
-			$translations = ["_etag" => "M".microtime(1)];
-			$translations['grommunio_web'] = $this->getTranslationsFromFile(LANGUAGE_DIR . $entry . '/LC_MESSAGES/grommunio_web.mo');
-			if (!$translations['grommunio_web']) {
+			$translations = $this->parseLanguage($entry);
+			if ($translations === false) {
 				continue;
 			}
-			if (isset($GLOBALS['PluginManager'])) {
-				// What we did above, we are also now going to do for each plugin that has translations.
-				$pluginTranslationPaths = $GLOBALS['PluginManager']->getTranslationFilePaths();
-				foreach ($pluginTranslationPaths as $pluginname => $path) {
-					$plugin_translations = $this->getTranslationsFromFile($path . '/' . $entry . '/LC_MESSAGES/plugin_' . $pluginname . '.mo');
-					if ($plugin_translations) {
-						$translations['plugin_' . $pluginname] = $plugin_translations;
-					}
-				}
-			}
-			$cache_table[$entry] = $last_id;
-			if ($memid) {
-				@shm_put_var($memid, $last_id, $translations);
-			}
-			if (strcmp($entry, $this->getSelected()) == 0) {
+			// Answer this request from what was just read, whether or not it caches.
+			if (strcmp($entry, (string) $this->getSelected()) == 0) {
 				$ret_val = $translations;
 			}
-			++$last_id;
+			if (!$memid) {
+				continue;
+			}
+			// Advertise only what the segment really holds. An entry pointing at a
+			// payload that failed to store makes every later request resolve it to
+			// nothing, which is served as an untranslated interface.
+			if (@shm_put_var($memid, $last_id, $translations)) {
+				$cache_table[$entry] = $last_id;
+				++$last_id;
+			}
 		}
 		closedir($handle);
 		if ($memid) {
 			@shm_put_var($memid, 0, $cache_table);
 			@shm_detach($memid);
 		}
-		if (empty($ret_val)) {
-			return ['grommunio_web' => []];
+
+		return $this->selectedTranslations($ret_val);
+	}
+
+	/**
+	 * Read one language's translations, including those of the plugins.
+	 *
+	 * @param string $entry name of the directory in LANGUAGE_DIR
+	 *
+	 * @return array|bool the translations per domain, or false if there are none
+	 */
+	private function parseLanguage($entry) {
+		$translations = ["_etag" => "M" . microtime(1)];
+		$translations['grommunio_web'] = $this->getTranslationsFromFile(LANGUAGE_DIR . $entry . '/LC_MESSAGES/grommunio_web.mo');
+		if (!$translations['grommunio_web']) {
+			return false;
+		}
+		if (isset($GLOBALS['PluginManager'])) {
+			// What we did above, we are also now going to do for each plugin that has translations.
+			$pluginTranslationPaths = $GLOBALS['PluginManager']->getTranslationFilePaths();
+			foreach ($pluginTranslationPaths as $pluginname => $path) {
+				$plugin_translations = $this->getTranslationsFromFile($path . '/' . $entry . '/LC_MESSAGES/plugin_' . $pluginname . '.mo');
+				if ($plugin_translations) {
+					$translations['plugin_' . $pluginname] = $plugin_translations;
+				}
+			}
 		}
 
-		return $ret_val;
+		return $translations;
+	}
+
+	/**
+	 * Hand back the translations that were found, and say so when there are none.
+	 *
+	 * An empty set means the entire interface falls back to its English msgids, which
+	 * is worth a line in the log: it is otherwise indistinguishable from a user who
+	 * selected English, and the .mo files themselves are usually fine.
+	 *
+	 * @param array|bool $translations the translations found for the selected language
+	 *
+	 * @return array
+	 */
+	private function selectedTranslations($translations) {
+		if (!empty($translations)) {
+			return $translations;
+		}
+		error_log(sprintf("No translations available for language '%s'", (string) $this->getSelected()));
+
+		return ['grommunio_web' => []];
 	}
 
 	/**

--- a/server/includes/core/class.language.php
+++ b/server/includes/core/class.language.php
@@ -76,27 +76,86 @@ class Language {
 		}
 		$lang = (empty($lang) || str_starts_with($lang, '.') || $lang == "C") ? LANG : $lang; // default language fix
 
-		if ($this->is_language($lang)) {
-			$this->lang = $lang;
-			$this->bindTextDomain($lang);
-			$tmp_translations = $this->getTranslations();
-			$translations = [];
-			foreach ($tmp_translations as $program => $resources) {
-				if (substr($program, 0, 1) == '_')
-					continue;
-				$resourcesCount = count($resources);
-				for ($i = 0; $i < $resourcesCount; ++$i) {
-					$msgid = $resources[$i]['msgid'];
-					if (isset($msgid)) {
-						$translations[$msgid] = $resources[$i]['msgstr'];
-					}
+		$available = $this->findLanguage($lang);
+		if ($available === false) {
+			error_log(sprintf("Unknown language: '%s'", $lang));
+
+			return;
+		}
+		if ($available !== $lang) {
+			error_log(sprintf("Unknown language: '%s', falling back to '%s'", $lang, $available));
+		}
+
+		$this->lang = $available;
+		$this->bindTextDomain($available);
+		$tmp_translations = $this->getTranslations();
+		$translations = [];
+		foreach ($tmp_translations as $program => $resources) {
+			if (substr($program, 0, 1) == '_')
+				continue;
+			$resourcesCount = count($resources);
+			for ($i = 0; $i < $resourcesCount; ++$i) {
+				$msgid = $resources[$i]['msgid'];
+				if (isset($msgid)) {
+					$translations[$msgid] = $resources[$i]['msgstr'];
 				}
 			}
-			$GLOBALS['translations'] = $translations;
 		}
-		else {
-			error_log(sprintf("Unknown language: '%s'", $lang));
+		$GLOBALS['translations'] = $translations;
+	}
+
+	/**
+	 * Find an installed language directory for the requested language.
+	 *
+	 * The requested language does not always name a directory in LANGUAGE_DIR. gromox
+	 * hands out PR_EC_USER_LANGUAGE as the `users.lang` column with ".UTF-8" appended,
+	 * so a bare language code stored there - "de" rather than "de_DE" - arrives here as
+	 * "de.UTF-8", for which no directory exists. Dropping such a value means serving a
+	 * client with an empty translation set, i.e. an entirely English interface that the
+	 * user cannot correct in Settings, because PR_EC_USER_LANGUAGE takes precedence over
+	 * the stored setting. Prefer a territory variant of the same language over that.
+	 *
+	 * @param string $lang Language code (eg nl_NL.UTF-8)
+	 *
+	 * @return bool|string the language to use, or false if none is installed
+	 */
+	private function findLanguage($lang) {
+		if ($this->is_language($lang)) {
+			return $lang;
 		}
+
+		$resolved = self::resolveLanguage($lang);
+		if ($resolved !== $lang && $this->is_language($resolved)) {
+			return $resolved;
+		}
+
+		// Any variant of the same language beats English. Try the territory that
+		// repeats the language code first ("de" -> "de_DE"), which is the usual
+		// spelling, and settle for the first one installed otherwise.
+		$base = strstr($lang, '_', true);
+		if ($base === false) {
+			$base = stristr($lang, '.', true);
+		}
+		if ($base === false) {
+			$base = $lang;
+		}
+		if (preg_match('/^[a-z]{2,3}$/i', $base)) {
+			// The language configured by the administrator wins when it is a variant
+			// of the same language, so its territory is not silently overruled.
+			if (strcasecmp($base, (string) strstr(LANG, '_', true)) == 0 && $this->is_language(LANG)) {
+				return LANG;
+			}
+			$candidates = glob(LANGUAGE_DIR . strtolower($base) . '_' . strtoupper($base) . '.UTF-8');
+			if (empty($candidates)) {
+				$candidates = glob(LANGUAGE_DIR . strtolower($base) . '_*.UTF-8');
+				sort($candidates);
+			}
+			if (!empty($candidates)) {
+				return basename($candidates[0]);
+			}
+		}
+
+		return $this->is_language(LANG) ? LANG : false;
 	}
 
 	/**

--- a/server/includes/core/class.language.php
+++ b/server/includes/core/class.language.php
@@ -78,6 +78,7 @@ class Language {
 
 		if ($this->is_language($lang)) {
 			$this->lang = $lang;
+			$this->bindTextDomain($lang);
 			$tmp_translations = $this->getTranslations();
 			$translations = [];
 			foreach ($tmp_translations as $program => $resources) {
@@ -96,6 +97,46 @@ class Language {
 		else {
 			error_log(sprintf("Unknown language: '%s'", $lang));
 		}
+	}
+
+	/**
+	 * Bind the gettext text domain for the given language.
+	 *
+	 * The JavaScript client receives its strings from getTranslations(), but the PHP
+	 * side - templates, modules and plugins - calls _() directly, which is the gettext
+	 * extension's function. gettext only returns a translation once LC_MESSAGES names
+	 * an actual locale and the text domain is bound to the directory holding the .mo
+	 * files; without both it hands back the msgid, so every server-rendered string
+	 * stays English no matter which language the user selected.
+	 *
+	 * @param string $lang Language code (eg nl_NL.UTF-8)
+	 */
+	private function bindTextDomain($lang) {
+		if (!function_exists('bindtextdomain') || !defined('LC_MESSAGES')) {
+			return;
+		}
+		// bindtextdomain() resolves a relative path against the working directory at
+		// lookup time, which is not ours to rely on, so hand it an absolute one.
+		$dir = realpath(LANGUAGE_DIR);
+		if ($dir === false) {
+			return;
+		}
+
+		// A locale the system does not have leaves LC_MESSAGES at "C", under which
+		// gettext returns the msgid unchanged. Offer the alternative spellings as
+		// well: glibc writes the codeset as "utf8", and the plain language code
+		// exists on hosts that generated the locale without one.
+		$locales = [$lang];
+		$base = strstr($lang, '.', true);
+		if ($base !== false) {
+			$locales[] = $base . '.utf8';
+			$locales[] = $base;
+		}
+		setlocale(LC_MESSAGES, ...$locales);
+
+		bindtextdomain('grommunio_web', $dir);
+		bind_textdomain_codeset('grommunio_web', 'UTF-8');
+		textdomain('grommunio_web');
 	}
 
 	public static function getstring($string) {

--- a/server/includes/translations.js.php
+++ b/server/includes/translations.js.php
@@ -22,7 +22,14 @@ if ($translations && array_key_exists("_etag", $translations)) {
 		}
 	}
 } else {
+	/*
+	 * No strings to hand out. Do not let this answer be stored: a client that keeps
+	 * it shows an untranslated interface until the URL changes, which happens once
+	 * per release, and nothing done on the server in the meantime reaches it.
+	 */
 	header("Etag: 0");
+	header('Cache-Control: no-store');
+	header('Expires: 0');
 }
 
 


### PR DESCRIPTION
Four defects in language handling, one commit each. All of them share a failure mode: the interface silently falls back to its English msgids, which is indistinguishable from a user who chose English, and nothing is written to any log.

### 1. An unknown language code discards every translation

`Language::setLanguage()` logged `Unknown language` and returned without setting `$this->lang`, so `getSelected()` returned null, `getTranslations()` had nothing to look up, and the client received a `translations.js` whose entire payload is `this.translations["grommunio_web"] = new Object();`. The page then renders `<html lang="">` and requests `load=translations.js&lang=` with an empty parameter.

This is reachable from ordinary provisioning. gromox returns `PR_EC_USER_LANGUAGE` as the `users.lang` column with `.UTF-8` appended, so a bare language code stored there — `de` rather than `de_DE` — arrives as `de.UTF-8`, and no such directory exists. The user cannot correct it in Settings either, because `Settings::getSessionSettings()` lets `PR_EC_USER_LANGUAGE` take precedence over the stored `zarafa/v1/main/language` value.

`setLanguage()` now maps the request onto an installed directory: the value itself, then its `.UTF-8`-resolved form, then a territory variant of the same language, preferring the configured `LANG` when that is a variant of the same language so its territory is not silently overruled. Only a genuinely unknown language falls through to `LANG`, and every coercion is still logged.

### 2. PHP-side `_()` never translates anything

Roughly 1100 `_()` call sites in PHP — the login template, the welcome screen, `"You have been automatically logged out"`, the server modules and the bundled plugins — are the gettext extension's function, but nothing in the tree binds a text domain. `bindtextdomain()`, `bind_textdomain_codeset()` and `textdomain()` appear nowhere, and the only `setlocale()` call is `setlocale(LC_CTYPE, ...)` in `server/includes/bootstrap.php`, which does not affect `LC_MESSAGES`. With an unbound domain and a `C` message locale, gettext returns the msgid, so `_()` is an identity function in every language. `Language::getstring()` looks like it was written for this job but has no callers anywhere in the tree.

The domain is now bound in `setLanguage()`, so every entry point picks it up. Only `LC_MESSAGES` is set, never `LC_ALL`, so number and date formatting are untouched; `bindtextdomain()` receives an absolute path from `realpath(LANGUAGE_DIR)`, since it would otherwise resolve a relative path against the working directory at lookup time; and `setlocale()` is offered the alternative spellings, because a locale the host has not generated leaves `LC_MESSAGES` at `C`, which silently disables translation.

### 3. An unusable translation cache is never repaired

The parsed translations live in a 16 MB SysV shared memory segment. When the cached entry for the selected language could not be read, `getTranslations()` removed **only** variable 0, the small index table, and returned an empty translation set. The payload variables stayed allocated, so the next rebuild had to fit a second full copy into the same segment; `shm_put_var()` is called with its result discarded at what was line 249, so those writes fail unnoticed while the index entries are recorded anyway — and every later request then resolves an entry to nothing. Measured on a stock install: 34 languages occupy 12.9 MB of the 16 MB segment with no plugin domains present, so the headroom for a second copy does not exist. Observed in production: variable 0 in a state where `shm_get_var()` does not return an array at all, which only `ipcrm -M` cleared, since the segment outlives both the request and a service restart.

`getTranslations()` now discards the whole segment rather than one variable when the cache cannot answer, records an index entry only when the payload actually stored, and — the invariant that matters — answers from the freshly parsed `.mo` files whenever the cache cannot serve, instead of returning an empty set. A language that is merely absent from an otherwise valid table is read from disk directly, without rewriting the languages already cached. An empty result is now logged.

### 4. An empty translation set could be cached by the client

`translations.js` is served with `max-age`, so a client that receives an empty payload keeps it — for 13 weeks before commit b72fe89, and until the URL's `version=` parameter changes at the next release. Nothing done on the server reaches such a client. The empty response now carries `Cache-Control: no-store`.

