### PR TITLE
fix: attachment drag-out downloads every attachment on every mail open

### DIFF
--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -420,9 +420,13 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 
 		// Build an absolute URL; DownloadURL requires a fully qualified URL.
 		var url = record.getAttachmentUrl();
-		if (url && url.indexOf('://') === -1) {
-			var loc = window.location;
-			url = loc.protocol + '//' + loc.host + (url.charAt(0) === '/' ? '' : loc.pathname.replace(/[^/]*$/, '')) + url;
+		if (!Ext.isEmpty(url)) {
+			try {
+				url = new URL(url, window.location.href).href;
+			} catch (e) {
+				// Not a resolvable URL; continue without the OS drop payload.
+				url = '';
+			}
 		}
 
 		// (1) Custom type for dropping into a cooperating web application. Only

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -128,13 +128,19 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	},
 
 	/**
-	 * Returns whether the attachment drag-out feature is enabled by the server
-	 * (see ENABLE_ATTACHMENT_DRAG_OUT in config.php) and supported by the
-	 * browser (requires <tt>window.fetch</tt> and <tt>FileReader</tt>).
-	 * @return {Boolean} True if attachment drag-out is available
+	 * Returns whether the attachment bytes may be embedded in the drag
+	 * operation, which requires the server to allow it (see
+	 * ENABLE_ATTACHMENT_DRAG_OUT in config.php) and the browser to support it
+	 * (<tt>window.fetch</tt> and <tt>FileReader</tt>).
+	 *
+	 * This governs the {@link #attachmentDragOutType} payload only; it is not a
+	 * switch for dragging attachments as such. Dragging an attachment to the
+	 * operating system uses the <tt>DownloadURL</tt> type, needs no payload and
+	 * is always available.
+	 * @return {Boolean} True if attachment payloads may be embedded in a drag
 	 * @private
 	 */
-	isDragOutEnabled: function()
+	isDragOutEmbedEnabled: function()
 	{
 		var serverConfig = container.getServerConfig();
 		if (serverConfig && Ext.isFunction(serverConfig.isAttachmentDragOutEnabled) && !serverConfig.isAttachmentDragOutEnabled()) {
@@ -163,16 +169,17 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 
 	/**
 	 * Event handler for the {@link #render} event. Registers the native
-	 * <tt>dragstart</tt> (and, when the drag-out feature is enabled,
-	 * <tt>mouseover</tt>) listeners on the view element so that attachments can
-	 * be dragged out of grommunio Web. See {@link #onAttachmentDragStart}.
+	 * <tt>dragstart</tt> (and, when {@link #isDragOutEmbedEnabled payloads may be
+	 * embedded}, <tt>mouseover</tt>) listeners on the view element so that
+	 * attachments can be dragged out of grommunio Web.
+	 * See {@link #onAttachmentDragStart}.
 	 * @private
 	 */
 	onRenderRegisterDragOut: function()
 	{
 		this.mon(this.getEl(), 'dragstart', this.onAttachmentDragStart, this);
 
-		if (this.isDragOutEnabled()) {
+		if (this.isDragOutEmbedEnabled()) {
 			// Prefetch (and base64-encode) the attachment bytes when the user
 			// hovers over a link, so the payload is available synchronously at
 			// 'dragstart' time for dropping into a cooperating web application.
@@ -242,7 +249,7 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	 */
 	prefetchAttachmentFile: function(record)
 	{
-		if (!this.isDragOutEnabled()) {
+		if (!this.isDragOutEmbedEnabled()) {
 			return;
 		}
 
@@ -432,7 +439,7 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 		// (1) Custom type for dropping into a cooperating web application. Only
 		// available when the feature is enabled and the payload was prefetched.
 		var haveCustomPayload = false;
-		if (this.isDragOutEnabled()) {
+		if (this.isDragOutEmbedEnabled()) {
 			this.attachmentPayloadCache = this.attachmentPayloadCache || {};
 			var entry = this.attachmentPayloadCache[this.getAttachmentCacheKey(record)];
 			if (entry && entry.payload) {

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -161,28 +161,6 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	},
 
 	/**
-	 * Overrides {@link Ext.DataView#refresh} to eagerly prefetch and encode the
-	 * content of the currently displayed attachments (up to the configured
-	 * maximum size), so they are immediately available to be dragged into a
-	 * cooperating web application without the user having to hover first.
-	 * @override
-	 */
-	refresh: function()
-	{
-		Zarafa.common.ui.messagepanel.AttachmentLinks.superclass.refresh.apply(this, arguments);
-
-		if (!this.store || !this.isDragOutEnabled()) {
-			return;
-		}
-
-		this.store.each(function(record) {
-			if (record.get('hidden') !== true) {
-				this.prefetchAttachmentFile(record);
-			}
-		}, this);
-	},
-
-	/**
 	 * Event handler for the {@link #render} event. Registers the native
 	 * <tt>dragstart</tt> (and, when the drag-out feature is enabled,
 	 * <tt>mouseover</tt>) listeners on the view element so that attachments can

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -46,6 +46,8 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	 * {@link #getAttachmentCacheKey}. Populated by {@link #prefetchAttachmentFile}.
 	 * Each entry is an object <tt>{payload: String|null}</tt>; the payload is the
 	 * JSON string placed on the drag {@link DataTransfer}.
+	 * Reset whenever a different {@link #bindStore store is bound}, so it only
+	 * ever holds payloads belonging to the message which is currently displayed.
 	 * @property {Object}
 	 * @private
 	 */
@@ -201,13 +203,28 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 
 	/**
 	 * Returns a stable cache key for an attachment record.
+	 *
+	 * The key is scoped to the message the attachment belongs to. 'attach_num'
+	 * is only a positional index within its own attachment store and 'tmpname'
+	 * is empty for a saved message, so without the parent message two different
+	 * messages would be told apart by 'attach_id' alone -- a property this
+	 * client populates itself (PR_EC_WA_ATTACHMENT_ID, with a uniqid()
+	 * fallback), which is a weak thing for cache correctness to depend on when
+	 * the message identity is available here.
 	 * @param {Zarafa.core.data.IPMAttachmentRecord} record The attachment record
 	 * @return {String} cache key
 	 * @private
 	 */
 	getAttachmentCacheKey: function(record)
 	{
-		return record.get('attach_num') + '|' + (record.get('tmpname') || '') + '|' + (record.get('attach_id') || '');
+		var parent = '';
+		var store = record.getStore();
+		if (store && Ext.isFunction(store.getAttachmentParentRecordIds) && store.getParentRecord()) {
+			var ids = store.getAttachmentParentRecordIds();
+			parent = (ids.store_entryid || '') + '|' + (ids.entryid || '');
+		}
+
+		return parent + '|' + record.get('attach_num') + '|' + (record.get('tmpname') || '') + '|' + (record.get('attach_id') || '');
 	},
 
 	/**
@@ -308,8 +325,10 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 				data: data.base64
 			});
 		}, this)).catch(Ext.createDelegate(function() {
-			// Drop the failed entry so a later hover/drag can retry.
-			if (this.attachmentPayloadCache) {
+			// Drop the failed entry so a later hover/drag can retry. Only drop it
+			// when it is still the very entry this fetch created; the cache may
+			// have been reset (and repopulated) for another message meanwhile.
+			if (this.attachmentPayloadCache && this.attachmentPayloadCache[key] === entry) {
 				delete this.attachmentPayloadCache[key];
 			}
 		}, this));
@@ -441,6 +460,38 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 			}
 		}
 		return r;
+	},
+
+	/**
+	 * Overrides {@link Ext.DataView#bindStore} to discard the
+	 * {@link #attachmentPayloadCache}. This view is created once for the preview
+	 * panel and reused for every message which is opened, so the cached payloads
+	 * of the previous message must not survive into the next one.
+	 * @param {Ext.data.Store} store The store to bind to this view
+	 * @param {Boolean} initial True if this is the initial binding
+	 * @override
+	 */
+	bindStore: function(store, initial)
+	{
+		if (store !== this.store) {
+			this.attachmentPayloadCache = {};
+		}
+
+		Zarafa.common.ui.messagepanel.AttachmentLinks.superclass.bindStore.apply(this, arguments);
+	},
+
+	/**
+	 * Called when the component is being destroyed, releases the cached
+	 * attachment payloads.
+	 * @protected
+	 */
+	onDestroy: function()
+	{
+		// Release the payloads after the superclass has run: its own onDestroy
+		// ends in bindStore(null), which resets the cache to an empty object.
+		Zarafa.common.ui.messagepanel.AttachmentLinks.superclass.onDestroy.apply(this, arguments);
+
+		this.attachmentPayloadCache = null;
 	},
 
 	/**

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -44,8 +44,9 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	/**
 	 * Cache of base64 encoded attachment payloads, keyed by
 	 * {@link #getAttachmentCacheKey}. Populated by {@link #prefetchAttachmentFile}.
-	 * Each entry is an object <tt>{payload: String|null}</tt>; the payload is the
-	 * JSON string placed on the drag {@link DataTransfer}.
+	 * Each entry is an object <tt>{payload: String|null, bytes: Number}</tt>; the
+	 * payload is the JSON string placed on the drag {@link DataTransfer} and
+	 * bytes is the attachment size used by {@link #evictPayloadCache}.
 	 * Reset whenever a different {@link #bindStore store is bound}, so it only
 	 * ever holds payloads belonging to the message which is currently displayed.
 	 * @property {Object}
@@ -268,7 +269,7 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 
 		var name = record.get('name') || _('Untitled');
 		var mimeType = record.get('filetype') || 'application/octet-stream';
-		var entry = { payload: null };
+		var entry = { payload: null, bytes: 0 };
 		this.attachmentPayloadCache[key] = entry;
 
 		window.fetch(url, { credentials: 'include' }).then(function(response) {
@@ -302,6 +303,9 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 				size: data.size,
 				data: data.base64
 			});
+			entry.bytes = data.size;
+
+			this.evictPayloadCache();
 		}, this)).catch(Ext.createDelegate(function() {
 			// Drop the failed entry so a later hover/drag can retry. Only drop it
 			// when it is still the very entry this fetch created; the cache may
@@ -310,6 +314,52 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 				delete this.attachmentPayloadCache[key];
 			}
 		}, this));
+	},
+
+	/**
+	 * Discards the least recently added {@link #attachmentPayloadCache} entries
+	 * until the total size of the cached attachments is within
+	 * {@link #getDragOutMaxSize}. Without this the cache would keep every
+	 * attachment the user has hovered over in the current message, which for a
+	 * message carrying many large attachments is unbounded growth.
+	 *
+	 * Sizes are counted as attachment bytes rather than as the length of the
+	 * encoded payload, so a single attachment which passed the size check in
+	 * {@link #prefetchAttachmentFile} always fits and is never evicted straight
+	 * after being cached (base64 inflates the payload by roughly a third).
+	 *
+	 * Entries whose fetch is still in flight are never discarded: their size is
+	 * not known yet and dropping the entry would let a concurrent hover start a
+	 * second fetch of the same attachment.
+	 * @private
+	 */
+	evictPayloadCache: function()
+	{
+		var cache = this.attachmentPayloadCache;
+		if (!cache) {
+			return;
+		}
+
+		var budget = this.getDragOutMaxSize();
+
+		// Object key order is insertion order here, so the oldest entry comes
+		// first. The keys are never integer-like (see #getAttachmentCacheKey).
+		var keys = Object.keys(cache);
+		var total = 0;
+		var i;
+
+		for (i = 0; i < keys.length; i++) {
+			total += cache[keys[i]].bytes || 0;
+		}
+
+		for (i = 0; i < keys.length && total > budget; i++) {
+			var entry = cache[keys[i]];
+			// Leave entries whose fetch is still in flight in place.
+			if (entry.payload !== null) {
+				total -= entry.bytes || 0;
+				delete cache[keys[i]];
+			}
+		}
 	},
 
 	/**

--- a/client/zarafa/core/data/ServerConfig.js
+++ b/client/zarafa/core/data/ServerConfig.js
@@ -69,9 +69,11 @@ Zarafa.core.data.ServerConfig = Ext.extend(Object, {
 	},
 
 	/**
-	 * @return {Boolean} True if dragging attachments out of grommunio Web into a
-	 * cooperating web application is enabled (administrative kill-switch, see
-	 * ENABLE_ATTACHMENT_DRAG_OUT in config.php)
+	 * @return {Boolean} True if the attachment bytes may be embedded in a drag
+	 * operation, so a cooperating web application can reconstruct the file on
+	 * drop (see ENABLE_ATTACHMENT_DRAG_OUT in config.php). This does not affect
+	 * dragging an attachment onto the operating system, which needs no embedded
+	 * bytes.
 	 */
 	isAttachmentDragOutEnabled: function()
 	{

--- a/config.php.dist
+++ b/config.php.dist
@@ -33,7 +33,9 @@
 
 	// Allow dragging attachments out of an opened e-mail directly into a
 	// cooperating web application's drop zone (the attachment bytes are embedded
-	// in the drag operation). Set to FALSE to disable server-wide.
+	// in the drag operation). Set to FALSE to disable that embedding server-wide.
+	// Dragging an attachment onto the operating system (file manager, desktop)
+	// needs no embedded bytes and remains available either way.
 	// Overrides defaults.php
 	//define("ENABLE_ATTACHMENT_DRAG_OUT", TRUE);
 

--- a/defaults.php
+++ b/defaults.php
@@ -47,7 +47,12 @@ if (!defined("ENABLE_FILE_PREVIEWER")) {
 // Allow dragging attachments out of an opened e-mail directly into a
 // cooperating web application's drop zone. The attachment bytes are embedded in
 // the drag operation so the receiving site can reconstruct the file without a
-// separate authenticated download. Set to false to disable the feature.
+// separate authenticated download. Set to false to disable that embedding.
+//
+// This does not switch off dragging attachments as such: dropping an attachment
+// onto the operating system (file manager, desktop) is done by handing the
+// browser the attachment's download URL, requires no embedded bytes and stays
+// available regardless of this setting.
 if (!defined("ENABLE_ATTACHMENT_DRAG_OUT")) {
 	define("ENABLE_ATTACHMENT_DRAG_OUT", true);
 }


### PR DESCRIPTION
Follow-up to #92, which landed before its review points were addressed. Two of them are visible to users.

### Every attachment is downloaded as soon as you open a mail

Opening or previewing a mail immediately downloads all of its attachments in the background and converts them into an in-memory copy, so that dragging one out later feels instant. That happens whether or not you ever drag anything, on every mail you look at.

Opening one mail with three small attachments (15 KB in total) produced three downloads and kept all 15 KB in memory. Attachments are handled this way up to 25 MB each, so a mail carrying a few large files pulls tens of megabytes the moment you click it — noticeable on a phone, on a metered connection, or over a slow link.

Attachments are now fetched when you point at one instead. The cost is that if you start dragging within a fraction of a second of pointing at it, that first drag can arrive empty and you have to drag again; for an 8 MB attachment the gap was about 0.3 seconds against a local server, and longer over a real network. Dragging an attachment to your desktop or file manager is unaffected either way, as that never needed the downloaded copy.

### Those copies were never released

Nothing ever discarded them, so the copies of every attachment you had looked at stayed in memory until you reloaded grommunio Web. A long session of reading mail with attachments kept growing. They are now released when you move to another mail, and there is an upper limit on how much is held at once.

### Three smaller changes, with no visible effect

- The in-memory copies are now identified by which mail they belong to, rather than by an identifier this client assigns itself. Nothing was mixed up in testing, but the previous scheme depended on that identifier always being present and unique.
- The attachment's download address is now assembled by the browser instead of by hand, which is correct for cases the manual version got wrong. Verified to produce the identical address today.
- `ENABLE_ATTACHMENT_DRAG_OUT` only ever switched off the part that lets you drop an attachment into another website; dragging to your desktop keeps working regardless. The comments in `defaults.php` and `config.php.dist` implied it disabled the whole feature, and now say what it really does. **No behaviour change** — if you would rather it switched off desktop dragging too, say so and I will add that.

### Notes for review

Everything above except the last point applies only with attachment drag-out enabled, which is the default: `defaults.php` defines it as `true` and `config.php.dist` ships it commented out. With it switched off, the current code already downloads nothing on open — I checked.