### PR TITLE
fix: dropped files are not attached outside the mail body editor

### DIFF
--- a/client/zarafa/common/ui/HtmlEditor.js
+++ b/client/zarafa/common/ui/HtmlEditor.js
@@ -189,9 +189,16 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 						// Rebuild a real FileList containing only the non-embeddable files
 						// so it is uploaded/attached exactly like a drop on the Attachments
 						// field would be.
+						//
+						// The FileList has to be built with the constructor of the window
+						// uploadFiles() will check it against, which is the active browser
+						// window rather than necessarily this one: a dialog opened in its
+						// own window has its own FileList, and an object built here would
+						// fail that instanceof check and be attached as a bare filename.
+						var activeBrowserWindow = Zarafa.core.BrowserWindowMgr.getActive() || window;
 						var uploadFileList = nonEmbeddable;
-						if (typeof DataTransfer !== 'undefined') {
-							var fileListBuilder = new DataTransfer();
+						if (Ext.isFunction(activeBrowserWindow.DataTransfer)) {
+							var fileListBuilder = new activeBrowserWindow.DataTransfer();
 							nonEmbeddable.forEach(function(f) {
 								fileListBuilder.items.add(f);
 							});

--- a/client/zarafa/common/ui/HtmlEditor.js
+++ b/client/zarafa/common/ui/HtmlEditor.js
@@ -151,6 +151,18 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 							return;
 						}
 
+						// Resolve the target record before anything is offered to the
+						// user, so we never show a confirmation we cannot honour.
+						var record = self.getAttachmentRecord();
+						var attachmentStore = record && Ext.isFunction(record.getSubStore) ? record.getSubStore('attachments') : undefined;
+						if (!attachmentStore) {
+							// This editor is not editing a record which can carry
+							// attachments (for instance the signature editor in the
+							// settings). Leave the drop to TinyMCE, which reports the
+							// unsupported file type itself.
+							return;
+						}
+
 						// Suppress TinyMCE's own "Dropped file type is not supported" error
 						// only when there is nothing for TinyMCE to embed. When the same drop
 						// also contains images, TinyMCE's paste handler (which runs after this
@@ -166,9 +178,6 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 						// used to join them remain real line breaks instead of being
 						// escaped as literal text.
 						var names = nonEmbeddable.map(function(f) { return '\u2022 ' + Ext.util.Format.htmlEncode(f.name); });
-
-						// Capture the record reference before the async callback.
-						var record = self.record;
 
 						// Zarafa.core.data.IPMAttachmentStore#uploadFiles() only treats its
 						// argument as "real" files (with size/type/contents) if it is a
@@ -194,15 +203,14 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 							_('The following files cannot be embedded in the message body. Add them as attachments instead?') +
 								'<br><br>' + names.join('<br>'),
 							function(btn) {
-								if (btn !== 'yes' || !record) {
+								if (btn !== 'yes') {
 									return;
 								}
 
-								var store = record.getSubStore('attachments');
 								// Run the same validation (max attachment count/size limits)
 								// that a direct drop on the Attachments field would perform.
-								if (store && store.canUploadFiles(uploadFileList, { container: this.getEl() })) {
-									store.uploadFiles(uploadFileList);
+								if (attachmentStore.canUploadFiles(uploadFileList, { container: this.getEl() })) {
+									attachmentStore.uploadFiles(uploadFileList);
 								}
 							}.createDelegate(self)
 						);
@@ -1132,6 +1140,30 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 	bindRecord: function(record)
 	{
 		this.record = record;
+	},
+
+	/**
+	 * Returns the record which a file dropped onto the editor body should be
+	 * attached to.
+	 *
+	 * {@link #bindRecord} is only called by
+	 * {@link Zarafa.mail.dialogs.MailCreatePanel the mail compose panel}, so for
+	 * every other editor -- appointment, task, contact, note and the quick-item
+	 * widgets -- the record has to be taken from the dialog which owns it. This
+	 * is the same lookup {@link Zarafa.common.form.TextArea} performs for the
+	 * plain-text body.
+	 * @return {Zarafa.core.data.IPMRecord} The record being edited, or undefined
+	 * when this editor is not editing a record at all.
+	 */
+	getAttachmentRecord: function()
+	{
+		if (this.record) {
+			return this.record;
+		}
+
+		var panel = this.findParentByType('zarafa.recordcontentpanel');
+
+		return panel ? panel.record : undefined;
 	},
 
 	/**


### PR DESCRIPTION
### Dropping a file on an appointment, task or contact asks to attach it, then does nothing

Drop a file that cannot be shown inside the text — a PDF, say — onto the body of an appointment, a task or a contact, and you are asked *"Add as attachment?"*. Answer Yes and nothing happens. No attachment, no error, no hint that anything went wrong. It only works when writing a mail.

The reason is that the question is asked before anything checks which item the file would be attached to, and outside the mail window nothing had ever told the editor. Only the mail composer does that; the appointment, task and contact windows never did, so the answer was quietly discarded.

The editor now works out for itself which item it belongs to, exactly as the plain-text version of the same box already did. That fixes appointment, task and contact in one go.

A related annoyance goes with it: where a dropped file genuinely cannot be attached — the signature editor in the settings, for instance — the question is no longer asked at all. You get the editor's own "file type is not supported" message instead of a dialog that cannot do what it offers.

### Attachments could arrive empty when a dialog has its own window

If you open an appointment in its own browser window and drop a file on it, the file was attached as a bare name: 0 bytes and no file type. It looks attached, and it is empty. The upload step did not recognise what it was handed as a real file, because it came from the main window rather than the one you were working in.

### What I tested

Each dialog opened for real, a real file dropped on the body, the question answered, then the resulting attachment checked — including its size and file type, not just its name.

| Dialog | Before | After |
|---|---|---|
| Appointment | asks, then **attaches nothing** | attached, 2 KB, correct type |
| Task | — | attached, correct type |
| Contact | — | attached, correct type |
| Mail | already worked | still works |

Two limits worth stating. **Notes are not affected** — a note body is the plain-text box, which already worked, and still does. 