### PR TITLE
core: block the dialog while a save or send is in flight

### DIFF
--- a/client/zarafa/core/ui/MessageContentPanel.js
+++ b/client/zarafa/core/ui/MessageContentPanel.js
@@ -274,6 +274,7 @@ Zarafa.core.ui.MessageContentPanel = Ext.extend(Zarafa.core.ui.RecordContentPane
 			if (sendAction) {
 				this.fireEvent('aftersendrecord', this, this.record);
 				this.isSending = false;
+				this.unlockPendingAction();
 			}
 
 			if (isSending && this.closeOnSend && sendAction) {
@@ -302,6 +303,7 @@ Zarafa.core.ui.MessageContentPanel = Ext.extend(Zarafa.core.ui.RecordContentPane
 
 		if (type !== "open") {
 			this.isSending = false;
+			this.unlockPendingAction();
 		}
 	},
 
@@ -327,6 +329,11 @@ Zarafa.core.ui.MessageContentPanel = Ext.extend(Zarafa.core.ui.RecordContentPane
 		}
 
 		this.isSending = true;
+
+		// Lock here rather than when the store starts saving: the validation queue
+		// below is asynchronous, so without this the Send button stays live for the
+		// whole of it.
+		this.lockPendingAction(this.sendingText.msg);
 
 		// Start the validation queue to determine if the record can be
 		// send to the recipients correctly. If successful, onCompleteValidateSendRecord
@@ -612,7 +619,10 @@ Zarafa.core.ui.MessageContentPanel = Ext.extend(Zarafa.core.ui.RecordContentPane
 				this.fireEvent('sendrecord', this, this.record);
 			}
 		} else {
+			// Validation refused the send (no recipients, unresolved names, ...).
+			// Nothing is in flight, so give the dialog back to the user.
 			this.isSending = false;
+			this.unlockPendingAction();
 		}
 	},
 

--- a/client/zarafa/core/ui/RecordContentPanel.js
+++ b/client/zarafa/core/ui/RecordContentPanel.js
@@ -343,6 +343,51 @@ Zarafa.core.ui.RecordContentPanel = Ext.extend(Zarafa.core.ui.ContentPanel, {
 	},
 
 	/**
+	 * Block interaction with this panel while a save or send is in flight.
+	 *
+	 * The {@link #isSaving} and {@link #isSending} re-entrancy guards already stop a
+	 * second request from being issued, but they are invisible: the Save/Send button
+	 * stays lit and clickable, and nothing on screen says the first click registered.
+	 * That is what makes people click again. Masking the panel both blocks the second
+	 * click and shows that something is happening.
+	 *
+	 * Deliberately independent of {@link #showInfoMask}: that config only governs the
+	 * "Saving…" notifier, and turning the notification off should not also turn off
+	 * the input blocking.
+	 *
+	 * @param {String} text The message to show on the mask
+	 * @protected
+	 */
+	lockPendingAction: function(text)
+	{
+		if (!this.rendered || !this.el || this.isPendingActionLocked === true) {
+			return;
+		}
+
+		this.isPendingActionLocked = true;
+		this.el.mask(text || '', 'x-mask-loading');
+	},
+
+	/**
+	 * Undo {@link #lockPendingAction}. Safe to call when no lock is held, so every
+	 * path that clears {@link #isSaving} or {@link #isSending} can call it without
+	 * first checking - including the failure paths, where leaving the panel masked
+	 * would strand the user in a dialog they cannot use or close.
+	 * @protected
+	 */
+	unlockPendingAction: function()
+	{
+		if (this.isPendingActionLocked !== true) {
+			return;
+		}
+
+		this.isPendingActionLocked = false;
+		if (this.rendered && this.el) {
+			this.el.unmask();
+		}
+	},
+
+	/**
 	 * See {@link Zarafa.core.plugins.RecordComponentPlugin#setRecord}.
 	 *
 	 * @param {Zarafa.core.data.MAPIRecord} record The record to set
@@ -596,6 +641,7 @@ Zarafa.core.ui.RecordContentPanel = Ext.extend(Zarafa.core.ui.ContentPanel, {
 
 			if(!this.hasInternalAction()) {
 				this.displayInfoMask();
+				this.lockPendingAction(this.savingText.msg);
 			}
 		}
 	},
@@ -620,6 +666,7 @@ Zarafa.core.ui.RecordContentPanel = Ext.extend(Zarafa.core.ui.ContentPanel, {
 			}
 
 			this.isSaving = false;
+			this.unlockPendingAction();
 			this.fireEvent('aftersaverecord', this, this.record);
 
 			if (this.closeOnSave) {
@@ -655,6 +702,7 @@ Zarafa.core.ui.RecordContentPanel = Ext.extend(Zarafa.core.ui.ContentPanel, {
 			} else {
 				this.hideInfoMask(false);
 				this.isSaving = false;
+				this.unlockPendingAction();
 			}
 		}
 	},


### PR DESCRIPTION
### What happens today

Click **Save** or **Send** and nothing on screen changes. The button stays lit and still clickable, and there is no sign that the click did anything until the window closes on its own. So people click a second time.

### What this changes

While the save or send is being carried out, the dialog is greyed out with a "Saving" / "Sending" indicator over it, and clicking again is not possible.

When it finishes, the dialog closes as it did before.

If the send is refused instead — a message with no recipients, for example — the grey-out disappears again and you can carry on editing.

Nothing else changes.
