### PR TITLE
search: accept search prefixes in the user's own language

### DIFF
--- a/client/zarafa/advancesearch/KQLParser.js
+++ b/client/zarafa/advancesearch/KQLParser.js
@@ -9,6 +9,228 @@ Zarafa.advancesearch.KQLParser = Ext.extend(Object, {
 	lexer: null,
 
 	/**
+	 * The canonical KQL field names, in collision-priority order: when two
+	 * fields would end up with the same localized alias, the one listed first
+	 * keeps it.
+	 * @property
+	 * @type Array
+	 */
+	kqlKeys: ['subject', 'from', 'to', 'cc', 'bcc', 'body', 'sender', 'attachment', 'category', 'unread', 'type', 'date'],
+
+	/**
+	 * The subset of {@link #kqlKeys} that this parser turns into a restriction.
+	 * 'unread', 'type' and 'date' are handled by the search tool box instead, so
+	 * they must stay out of the lexer or {@link #isKqlQuery} would start
+	 * reporting explicit syntax for queries that never used it.
+	 * @property
+	 * @type Array
+	 */
+	restrictionKeys: ['body', 'attachment', 'subject', 'sender', 'from', 'to', 'cc', 'bcc', 'category'],
+
+	/**
+	 * Characters that stop a translated label from being usable as a prefix:
+	 * whitespace and the KQL operators would break the token, and the rest are
+	 * regular expression metacharacters we would rather not see in an alias.
+	 * @property
+	 * @type RegExp
+	 */
+	unusableAliasRe: /[\s :=<>()[\]{}"'`|&!^$*?+\\/,;~%#@]/,
+
+	/**
+	 * Minimum length of a localized alias. Catalan, Spanish and Italian all
+	 * translate "To" to a single letter, which is far too small a token to
+	 * claim the prefix namespace with.
+	 * @property
+	 * @type Number
+	 */
+	minAliasLength: 2,
+
+	keywordLabels: null,
+	keywordAliasCache: null,
+	keywordPatternCache: null,
+
+	/**
+	 * The user-visible label for every canonical field name. Also the source of
+	 * the localized prefixes - see {@link #getKeywordAliasMap}.
+	 * @return {Object} Map of canonical key to translated label
+	 */
+	getKeywordLabels: function() {
+		if ( !this.keywordLabels ) {
+			this.keywordLabels = {
+				'subject': _('Subject'),
+				'from': _('From'),
+				'to': _('To'),
+				'cc': _('Cc'),
+				'bcc': _('Bcc'),
+				'body': _('Body'),
+				'sender': _('Sender'),
+				'attachment': _('Attachment'),
+				'category': _('Category'),
+				'unread': _('Unread'),
+				'type': _('Type'),
+				'date': _('Date')
+			};
+		}
+
+		return this.keywordLabels;
+	},
+
+	/**
+	 * Whether a translated label can serve as a search prefix.
+	 * @param {String} label The translated label
+	 * @return {Boolean} True if it can be typed as "<label>:value"
+	 */
+	isUsableAlias: function(label) {
+		if ( !label ) {
+			return false;
+		}
+
+		var alias = String(label);
+		if ( alias.length < this.minAliasLength || alias.length > 24 ) {
+			return false;
+		}
+		// '-' is a boolean operator in its own right.
+		if ( alias.charAt(0) === '-' ) {
+			return false;
+		}
+		if ( this.unusableAliasRe.test(alias) ) {
+			return false;
+		}
+		var upper = alias.toUpperCase();
+		if ( upper === 'AND' || upper === 'OR' || upper === 'NOT' ) {
+			return false;
+		}
+
+		return true;
+	},
+
+	/**
+	 * Escapes a string for literal use inside a regular expression.
+	 * @param {String} str The string to escape
+	 * @return {String} The escaped string
+	 */
+	regExpEscape: function(str) {
+		return String(str).replace(/[.*+?^${}()|[\]\\/-]/g, '\\$&');
+	},
+
+	/**
+	 * Every accepted spelling of a search prefix, mapped to its canonical field
+	 * name, so that a German user can type "von:" and a French one "objet:"
+	 * instead of the English "from:" and "subject:".
+	 *
+	 * The aliases are derived from the labels the UI already shows for each
+	 * field, so no separate list has to be kept in step with the translations.
+	 *
+	 * Two rules keep this predictable:
+	 *
+	 * - The canonical English names are claimed first and are never
+	 *   overwritten. Should some language translate one field's label to
+	 *   another field's English name, the English meaning wins - queries are
+	 *   stored and shared in canonical form, and silently repointing a prefix
+	 *   at a different property would change what those stored queries mean.
+	 * - Where two fields share a label, the one listed first in the given key
+	 *   order keeps it, rather than whichever happened to be iterated last.
+	 *
+	 * @param {Array} keys (optional) The canonical keys to include
+	 * @return {Object} Map of lower-cased alias to canonical key
+	 */
+	getKeywordAliasMap: function(keys) {
+		keys = keys || this.kqlKeys;
+		var cacheKey = keys.join('|');
+		this.keywordAliasCache = this.keywordAliasCache || {};
+		if ( this.keywordAliasCache[cacheKey] ) {
+			return this.keywordAliasCache[cacheKey];
+		}
+
+		var labels = this.getKeywordLabels();
+		var map = {};
+		var i;
+
+		for ( i = 0; i < keys.length; i++ ) {
+			map[keys[i]] = keys[i];
+		}
+
+		for ( i = 0; i < keys.length; i++ ) {
+			var label = labels[keys[i]];
+			if ( !this.isUsableAlias(label) ) {
+				continue;
+			}
+			var alias = String(label).toLowerCase();
+			if ( !map.hasOwnProperty(alias) ) {
+				map[alias] = keys[i];
+			}
+		}
+
+		this.keywordAliasCache[cacheKey] = map;
+		return map;
+	},
+
+	/**
+	 * A regular expression alternation matching any accepted prefix spelling.
+	 * Longest first, so the pattern stays correct even where one alias is a
+	 * prefix of another - German "an" and "anhang", for instance.
+	 * @param {Array} keys (optional) The canonical keys to include
+	 * @return {String} The alternation, without the surrounding group
+	 */
+	getKeywordPattern: function(keys) {
+		keys = keys || this.kqlKeys;
+		var cacheKey = keys.join('|');
+		this.keywordPatternCache = this.keywordPatternCache || {};
+		if ( this.keywordPatternCache[cacheKey] ) {
+			return this.keywordPatternCache[cacheKey];
+		}
+
+		var aliases = [];
+		var map = this.getKeywordAliasMap(keys);
+		for ( var alias in map ) {
+			if ( map.hasOwnProperty(alias) ) {
+				aliases.push(alias);
+			}
+		}
+		aliases.sort(function(a, b) {
+			return b.length - a.length || (a < b ? -1 : (a > b ? 1 : 0));
+		});
+
+		var escaped = [];
+		for ( var i = 0; i < aliases.length; i++ ) {
+			escaped.push(this.regExpEscape(aliases[i]));
+		}
+
+		this.keywordPatternCache[cacheKey] = escaped.join('|');
+		return this.keywordPatternCache[cacheKey];
+	},
+
+	/**
+	 * Resolves a typed prefix to its canonical field name.
+	 * @param {String} word The prefix as typed, in any accepted spelling
+	 * @param {Array} keys (optional) The canonical keys to consider
+	 * @return {String/Boolean} The canonical key, or false if unrecognised
+	 */
+	resolveKeyword: function(word, keys) {
+		if ( !word ) {
+			return false;
+		}
+
+		var map = this.getKeywordAliasMap(keys);
+		var raw = String(word);
+		return map[raw] || map[raw.toLowerCase()] || false;
+	},
+
+	/**
+	 * Removes "<prefix>:" from a query, whichever spelling was used. Intended
+	 * for building a human-readable title out of a search string.
+	 * @param {String} text The query
+	 * @param {Array} keys (optional) The canonical keys to consider
+	 * @return {String} The query without its prefixes
+	 */
+	stripKeywords: function(text, keys) {
+		var pattern = this.getKeywordPattern(keys);
+		// Not \b: it is defined over ASCII word characters and never fires in
+		// front of, say, a Cyrillic alias.
+		return String(text).replace(new RegExp('(^|[\\s(])(?:' + pattern + '):["\']?', 'gi'), '$1');
+	},
+
+	/**
 	 * Creates a tokenizer with rules to split strings into KQL tokens.
 	 * The tokenizer is an instance of Tokenizr.
 	 * See {@link https://github.com/rse/tokenizr}
@@ -22,17 +244,7 @@ Zarafa.advancesearch.KQLParser = Ext.extend(Object, {
 		// eslint-disable-next-line no-undef
 		this.lexer = new Tokenizr();
 
-		var keys = [
-			'body',
-			'attachment',
-			'subject',
-			'sender',
-			'from',
-			'to',
-			'cc',
-			'bcc',
-			'category'
-		];
+		var self = this;
 		var ops = [':', '=', '<>'];
 		var boolOps = ['AND', 'OR', 'NOT', '+', '-'];
 
@@ -73,9 +285,11 @@ Zarafa.advancesearch.KQLParser = Ext.extend(Object, {
 			ctx.accept('parenthesis', 'close');
 			ctx.pop();
 		}, 'parensclose');
-		this.lexer.rule(new RegExp('(' + keys.join('|') + ')(' + ops.join('|') + ')', 'i'), function(ctx, match) {
+		this.lexer.rule(new RegExp('(' + this.getKeywordPattern(this.restrictionKeys) + ')(' + ops.join('|') + ')', 'i'), function(ctx, match) {
 			ctx.ignore();
-			keyword = match[1].toLowerCase();
+			// Accept the localized spelling but hand the canonical name on, so
+			// everything downstream - propMap included - is unaffected.
+			keyword = self.resolveKeyword(match[1], self.restrictionKeys) || match[1].toLowerCase();
 			operator = match[2];
 		}, 'keyword');
 		this.lexer.rule(/"(.*?)"/, function(ctx, match) {

--- a/client/zarafa/advancesearch/dialogs/SearchPanel.js
+++ b/client/zarafa/advancesearch/dialogs/SearchPanel.js
@@ -5,6 +5,7 @@ Ext.namespace('Zarafa.advancesearch.dialogs');
  * @extends Ext.Panel
  * @xtype zarafa.searchpanel
  *
+ * #dependsFile client/zarafa/advancesearch/KQLParser.js
  */
 Zarafa.advancesearch.dialogs.SearchPanel = Ext.extend(Ext.Panel, {
 
@@ -363,8 +364,7 @@ Zarafa.advancesearch.dialogs.SearchPanel = Ext.extend(Ext.Panel, {
 		var searchField = this.searchToolbar.getAdvanceSearchField();
 
 		// Strip KQL field prefixes from the title for readability
-		var displayTitle = searchText
-			.replace(/\b(?:subject|from|to|cc|bcc|body|sender|attachment|category):["']?/gi, '')
+		var displayTitle = Zarafa.advancesearch.KQLParser.stripKeywords(searchText)
 			.replace(/["']/g, '')
 			.replace(/\b(AND|OR|NOT)\b/gi, '')
 			.replace(/\s+/g, ' ')

--- a/client/zarafa/common/searchfield/ui/SearchDropdownPanel.js
+++ b/client/zarafa/common/searchfield/ui/SearchDropdownPanel.js
@@ -6,6 +6,8 @@ Ext.ns('Zarafa.common.searchfield.ui');
  *
  * A dropdown panel shown below the search field on focus. Provides quick access
  * to recent search history, KQL filter fields and folder scope selection.
+ *
+ * #dependsFile client/zarafa/advancesearch/KQLParser.js
  */
 Zarafa.common.searchfield.ui.SearchDropdownPanel = Ext.extend(Ext.Panel, {
 
@@ -48,16 +50,30 @@ Zarafa.common.searchfield.ui.SearchDropdownPanel = Ext.extend(Ext.Panel, {
 	 * @type Array
 	 */
 	filterFields: [
-		{ key: 'subject', label: _('Subject') },
-		{ key: 'from', label: _('From') },
-		{ key: 'to', label: _('To') },
-		{ key: 'cc', label: _('Cc') },
-		{ key: 'bcc', label: _('Bcc') },
-		{ key: 'body', label: _('Body') },
-		{ key: 'attachment', label: _('Attachment') },
-		{ key: 'category', label: _('Category') },
-		{ key: 'unread', label: _('Unread'), value: 'true' }
+		{ key: 'subject' },
+		{ key: 'from' },
+		{ key: 'to' },
+		{ key: 'cc' },
+		{ key: 'bcc' },
+		{ key: 'body' },
+		{ key: 'attachment' },
+		{ key: 'category' },
+		{ key: 'unread', value: 'true' }
 	],
+
+	/**
+	 * The label to show for a filter. Taken from the same map that supplies the
+	 * accepted prefixes, so what the dropdown offers and what may be typed can
+	 * never disagree.
+	 * @param {String} key The canonical field name
+	 * @return {String} The translated label
+	 * @private
+	 */
+	getFilterLabel: function(key)
+	{
+		var labels = Zarafa.advancesearch.KQLParser.getKeywordLabels();
+		return labels[key] || key;
+	},
 
 	/**
 	 * Message type options for the dropdown.
@@ -269,7 +285,7 @@ Zarafa.common.searchfield.ui.SearchDropdownPanel = Ext.extend(Ext.Panel, {
 				html += ' data-filter-value="' + enc(f.value) + '"';
 			}
 			html += '>';
-			html += '<span class="k-search-filter-label">' + enc(f.label) + '</span>';
+			html += '<span class="k-search-filter-label">' + enc(this.getFilterLabel(f.key)) + '</span>';
 			html += '</span>';
 		}
 		html += '</div>';

--- a/client/zarafa/common/searchfield/ui/SearchTextField.js
+++ b/client/zarafa/common/searchfield/ui/SearchTextField.js
@@ -14,6 +14,7 @@ Ext.ns('Zarafa.common.searchfield.ui');
  * {@link #getValue} returns what the server expects.
  *
  * #dependsFile client/zarafa/common/searchfield/ui/SearchDropdownPanel.js
+ * #dependsFile client/zarafa/advancesearch/KQLParser.js
  */
 Zarafa.common.searchfield.ui.SearchTextField = Ext.extend(Ext.form.TextField, {
 
@@ -78,11 +79,13 @@ Zarafa.common.searchfield.ui.SearchTextField = Ext.extend(Ext.form.TextField, {
 	filterLabels: null,
 
 	/**
-	 * Supported KQL field names.
+	 * Supported KQL field names. Set from
+	 * {@link Zarafa.advancesearch.KQLParser#kqlKeys} so the field list and the
+	 * prefixes the parser accepts cannot drift apart.
 	 * @property
 	 * @type Array
 	 */
-	kqlFields: ['subject','from','to','cc','bcc','body','sender','attachment','category','unread','type','date'],
+	kqlFields: null,
 
 	/**
 	 * @constructor
@@ -99,20 +102,8 @@ Zarafa.common.searchfield.ui.SearchTextField = Ext.extend(Ext.form.TextField, {
 		});
 
 		this.tokens = [];
-		this.filterLabels = {
-			'subject': _('Subject'),
-			'from': _('From'),
-			'to': _('To'),
-			'cc': _('Cc'),
-			'bcc': _('Bcc'),
-			'body': _('Body'),
-			'sender': _('Sender'),
-			'attachment': _('Attachment'),
-			'category': _('Category'),
-			'unread': _('Unread'),
-			'type': _('Type'),
-			'date': _('Date')
-		};
+		this.kqlFields = Zarafa.advancesearch.KQLParser.kqlKeys.slice(0);
+		this.filterLabels = Zarafa.advancesearch.KQLParser.getKeywordLabels();
 
 		this.addEvents(
 			'beforestart',
@@ -492,15 +483,19 @@ Zarafa.common.searchfield.ui.SearchTextField = Ext.extend(Ext.form.TextField, {
 		}
 
 		var tokens = [];
-		var fieldsPattern = this.kqlFields.join('|');
+		var fieldsPattern = Zarafa.advancesearch.KQLParser.getKeywordPattern(this.kqlFields);
+		// No \b in front of the field group: it only fires between ASCII word
+		// characters, so it would reject every non-Latin alias outright. The
+		// trailing \S+ alternative already consumes whole whitespace-delimited
+		// runs, so the field alternative is only ever retried at a token start.
 		var regex = new RegExp(
-			'\\b(' + fieldsPattern + '):(\"[^\"]*\"|\'[^\']*\'|\\S*)|\\b(AND|OR|NOT)\\b|(\"[^\"]*\"|\'[^\']*\')|\\S+', 'gi'
+			'(' + fieldsPattern + '):(\"[^\"]*\"|\'[^\']*\'|\\S*)|\\b(AND|OR|NOT)\\b|(\"[^\"]*\"|\'[^\']*\')|\\S+', 'gi'
 		);
 
 		var match;
 		while ((match = regex.exec(query)) !== null) {
 			if (match[1]) {
-				var key = match[1].toLowerCase();
+				var key = Zarafa.advancesearch.KQLParser.resolveKeyword(match[1], this.kqlFields) || match[1].toLowerCase();
 				var val = match[2] || '';
 				if (val.length >= 2 &&
 					((val.charAt(0) === '"' && val.charAt(val.length - 1) === '"') ||
@@ -968,11 +963,14 @@ Zarafa.common.searchfield.ui.SearchTextField = Ext.extend(Ext.form.TextField, {
 			return { type: 'operator', key: upper };
 		}
 
-		// Check for field:value
+		// Check for field:value. The prefix may be typed in the user's own
+		// language; resolving it to the canonical name here is what keeps the
+		// query built by buildQuery(), and therefore the search history and
+		// everything sent to the server, in canonical English.
 		var colonIdx = raw.indexOf(':');
 		if (colonIdx > 0) {
-			var key = raw.substring(0, colonIdx).toLowerCase();
-			if (this.kqlFields.indexOf(key) !== -1) {
+			var key = Zarafa.advancesearch.KQLParser.resolveKeyword(raw.substring(0, colonIdx), this.kqlFields);
+			if (key) {
 				var value = raw.substring(colonIdx + 1);
 				if (value.length >= 2 &&
 					((value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') ||


### PR DESCRIPTION
### What happens today

The search box shows field names in your own language. In a German interface, typing `from:bob` produces a chip labelled **Von**. But typing `von:bob` does nothing at all.

So the search box shows you one word and only accepts a different one.

### What this changes

You can now type the prefix in your own language. In German, `von:`, `an:` and `betreff:` work just like `from:`, `to:` and `subject:`. The English prefixes keep working everywhere, unchanged.

This is not German-only. Every language accepts the field names it already displays, so each one gets its own prefixes without anything extra having to be translated. Where a translated name cannot work as a prefix — because it contains a space, for instance — that language simply keeps using the English one, exactly as before.

What gets stored in your search history and sent to the server does not change, so saved searches keep working and are unaffected by switching language.

`AND`, `OR` and `NOT` stay English. A prefix is always followed by a colon so it can never be confused with an ordinary word, but a plain "und" or "oder" typed in a search would suddenly stop meaning what you wrote.
