### PR TITLE
fix: reply quote missing body

### DIFF
--- a/client/zarafa/core/data/IPMRecord.js
+++ b/client/zarafa/core/data/IPMRecord.js
@@ -202,6 +202,76 @@ Zarafa.core.data.IPMRecord = Ext.extend(Zarafa.core.data.MAPIRecord, {
 	},
 
 	/**
+	 * Check whether this record claims to be {@link Zarafa.core.data.MAPIRecord#isOpened opened}
+	 * while carrying no body at all, which means the body must be fetched again.
+	 *
+	 * This state is reachable because the properties sent for a list row (and for
+	 * a table notification) do not include a body, but the record fields still
+	 * exist and hold an empty string. Applying such data onto an already opened
+	 * record therefore replaces its body with '', while the opened flag is only
+	 * ever set and never cleared. Since {@link Zarafa.core.data.MAPIRecord#open}
+	 * returns early for an opened record, nothing refetches the body afterwards.
+	 *
+	 * @return {Boolean} True if the record is opened but holds no body.
+	 */
+	isBodyMissing: function()
+	{
+		// A phantom has no server-side counterpart to load a body from.
+		if (this.phantom === true || !this.isOpened()) {
+			return false;
+		}
+
+		// A message can legitimately have no body at all. Reloading it would
+		// return an empty body again, so only ever ask once per record.
+		if (this.bodyReloadForced === true) {
+			return false;
+		}
+
+		if (!this.fields.containsKey('body') && !this.fields.containsKey('html_body')) {
+			return false;
+		}
+
+		return Ext.isEmpty(this.get('body')) && Ext.isEmpty(this.get('html_body'));
+	},
+
+	/**
+	 * Set to true while a reload has been requested by {@link #isBodyMissing} so
+	 * the request is not repeated for a message which has no body at all. It is
+	 * cleared again as soon as a body does arrive, which keeps a later loss of
+	 * the body repairable.
+	 * @property
+	 * @type Boolean
+	 */
+	bodyReloadForced: false,
+
+	/**
+	 * Request the body to be loaded again for a record which is
+	 * {@link Zarafa.core.data.MAPIRecord#isOpened opened} but {@link #isBodyMissing
+	 * carries no body}. A plain {@link Zarafa.core.data.MAPIRecord#open open} would
+	 * return early for such a record, so the load is forced.
+	 */
+	reloadBody: function()
+	{
+		this.bodyReloadForced = true;
+		this.open({forceLoad: true});
+	},
+
+	/**
+	 * Called by the store after the record was opened. Clears {@link #bodyReloadForced}
+	 * once a body has actually arrived, so that losing the body again later can
+	 * still be repaired by a reload.
+	 * @private
+	 */
+	afterOpen: function()
+	{
+		Zarafa.core.data.IPMRecord.superclass.afterOpen.apply(this, arguments);
+
+		if (!Ext.isEmpty(this.get('body')) || !Ext.isEmpty(this.get('html_body'))) {
+			this.bodyReloadForced = false;
+		}
+	},
+
+	/**
 	 * Helper function to get contents of body property of {@link Zarafa.core.data.IPMRecord IPMRecord}
 	 * @param {Boolean} preferHTML True if the HTML body should be returned or not, false if the plain-text
 	 * body should be returned.

--- a/client/zarafa/core/data/MAPIRecord.js
+++ b/client/zarafa/core/data/MAPIRecord.js
@@ -834,10 +834,14 @@ Zarafa.core.data.MAPIRecord = Ext.extend(Ext.data.Record, {
 	 */
 	idComparison: function(entryIdOne, entryIdTwo)
 	{
-		entryIdOne = Zarafa.core.EntryId.hasContactProviderGUID(entryIdOne) ?
+		// hasContactProviderGUID() dereferences the id, so a substore record
+		// without one must not reach it - a 'reply-to' record has no entryid
+		// when the stored sender has none. compareEntryIds() below already
+		// rejects anything which is not a string.
+		entryIdOne = Ext.isString(entryIdOne) && Zarafa.core.EntryId.hasContactProviderGUID(entryIdOne) ?
 			Zarafa.core.EntryId.unwrapContactProviderEntryId(entryIdOne): entryIdOne;
 
-		entryIdTwo = Zarafa.core.EntryId.hasContactProviderGUID(entryIdTwo) ?
+		entryIdTwo = Ext.isString(entryIdTwo) && Zarafa.core.EntryId.hasContactProviderGUID(entryIdTwo) ?
 			Zarafa.core.EntryId.unwrapContactProviderEntryId(entryIdTwo): entryIdTwo;
 
 		return Zarafa.core.EntryId.compareEntryIds(entryIdOne, entryIdTwo);

--- a/client/zarafa/mail/Actions.js
+++ b/client/zarafa/mail/Actions.js
@@ -134,12 +134,21 @@ Zarafa.mail.Actions = {
 					}
 				};
 
-				if (record.isOpened()) {
+				// An opened record which carries no body must be loaded again,
+				// otherwise the quote is built from an empty body and the reply
+				// ends up containing only the quoted header. See
+				// Zarafa.core.data.IPMRecord#isBodyMissing.
+				if (record.isOpened() && !record.isBodyMissing()) {
 					response = model.createResponseRecord(record, actionType);
 					Zarafa.core.data.UIFactory.openCreateRecord(response, config);
 				} else {
 					record.getStore().on('open', openHandler, record);
-					record.open();
+					if (record.isOpened()) {
+						// Flagged as opened, so a plain open() would return early.
+						record.reloadBody();
+					} else {
+						record.open();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

Replying to or forwarding a mail can produce a quote containing only the header — From / Sent / To / Subject — with the body of the original message missing entirely. Clicking Reply again does not help: every retry produces the same result. Viewing a different mail and coming back does fix it, which is the workaround users find on their own.

## Cause

The properties sent for a list row, and those sent with a table notification, do not include a body. The record fields still exist and hold an empty string, so applying such data onto an already opened record replaces its body with `''`. Since the `opened` flag is only ever set and never cleared, `MAPIRecord#open()` keeps returning early and nothing fetches the body again. `copy()` inherits the flag, so every copy made from such a record starts out opened and body-less too, and `RecordComponentPlugin` only queues its open task `if (!record.isOpened())`.

That the retries fail identically is `PreviewPanel#showRecordInPanel`, which returns early when the same record is selected again — so the panel keeps the same broken record until a different one replaces it.

## Fix

`IPMRecord#isBodyMissing()` detects a record which claims to be opened while holding no body, and the reply/forward path loads it again before building the quote. The request is made at most once per record while it stays body-less, so a message which genuinely has no body is not reloaded on every reply; the guard is cleared as soon as a body does arrive, which keeps a later loss of the body repairable.

The second commit is a prerequisite rather than a separate concern: forcing the load merges the substores again, and `MAPIRecord#idComparison()` passes both ids to `hasContactProviderGUID()`, which dereferences them. A `reply-to` record has no entryid whenever the stored sender has none, so comparing it threw a `TypeError` out of `createEntryIdObj()`. Only values which are strings are unwrapped now; `compareEntryIds()` already rejects anything else.

## Verification

Against a real gromox backend, driving the product's own Reply button in Chrome:

- With a record in the failing state, the composed quote goes from 804 characters (header block only) to 924 characters including the quoted body — same message, same button.
- Repeated replies, and reply after switching to another mail and back, quote the body across plain-text, HTML-fragment, full-HTML-document and >8 KB bodies.
- A message with genuinely no body still opens a compose window, does not hang behind a load mask, and is loaded a bounded number of times (no reload loop).
- The calendar, contacts, tasks and notes contexts still display items, with no uncaught exceptions. The same suite was run on the unpatched tree as a control, so it is not passing vacuously.

## Note on scope

The same guard would also apply in `RecordComponentPlugin#setRecord`, which would additionally repair the preview panel showing an empty body in this state. It is deliberately not included here: that plugin is shared by every context, and the reported symptom is the quote. Happy to add it if you would prefer the broader fix.

What leaves the record body-less in the first place is not identified — this repairs the state wherever it comes from, in the same spirit as fd0ee1516, a8ecc3c2e and daffbe05e.