### PR TITLE
fix: conversation view is never applied to shared mailboxes

### DIFF
--- a/client/zarafa/mail/MailStore.js
+++ b/client/zarafa/mail/MailStore.js
@@ -192,8 +192,22 @@ Zarafa.mail.MailStore = Ext.extend(Zarafa.core.data.ListModuleStore, {
 		}
 
 		// Check if this store contains the inbox. It is the only folder that can be rendered
-		// with conversation view.
-		var inbox = container.getHierarchyStore().getDefaultFolder('inbox');
+		// with conversation view. The inbox is taken from the mapi store this list belongs
+		// to, so the inbox of a shared mailbox is grouped like the own inbox. Stores without
+		// a receive folder (the public store) have no inbox and are shown flat.
+		var storeEntryId = this.storeEntryId;
+		if (!Ext.isString(storeEntryId)) {
+			// The list combines the contents of multiple folders, it has no single
+			// inbox to compare against.
+			return false;
+		}
+
+		var mapiStore = container.getHierarchyStore().getById(storeEntryId);
+		if (!mapiStore) {
+			return false;
+		}
+
+		var inbox = mapiStore.getDefaultFolder('inbox');
 		if (!inbox) {
 			return false;
 		}

--- a/server/includes/modules/class.maillistmodule.php
+++ b/server/includes/modules/class.maillistmodule.php
@@ -104,6 +104,7 @@ class MailListModule extends ListModule {
 							break;
 
 						case "conversationcounts":
+							$this->getDelegateFolderInfo($this->store);
 							$this->getConversationCounts($this->store, $action);
 							break;
 
@@ -202,6 +203,33 @@ class MailListModule extends ListModule {
 	}
 
 	/**
+	 * Opens the Sent Items folder of the given store, or returns false when it is
+	 * not available. A store does not necessarily have one (the public store), and
+	 * a shared mailbox can grant access to the Inbox while withholding Sent Items -
+	 * in that case the conversations of that mailbox simply have no sent
+	 * counterparts, which must not turn into an error for the whole request.
+	 *
+	 * @param object $store MAPI message store object
+	 *
+	 * @return bool|resource the Sent Items folder, or false when unavailable
+	 */
+	protected function openSentItemsFolder($store) {
+		$msgstoreProps = mapi_getprops($store, [PR_IPM_SENTMAIL_ENTRYID]);
+		if (!isset($msgstoreProps[PR_IPM_SENTMAIL_ENTRYID])) {
+			return false;
+		}
+
+		try {
+			return mapi_msgstore_openentry($store, $msgstoreProps[PR_IPM_SENTMAIL_ENTRYID]);
+		}
+		catch (MAPIException $e) {
+			$e->setHandled();
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns, for the given list of conversation ids, how many messages of each
 	 * conversation are in the Sent Items folder. The client uses this to know
 	 * which messages must be presented as a conversation even though only one
@@ -226,9 +254,8 @@ class MailListModule extends ListModule {
 				}
 			}
 
-			$msgstoreProps = mapi_getprops($store, [PR_IPM_SENTMAIL_ENTRYID]);
-			if (!empty($validIds) && isset($msgstoreProps[PR_IPM_SENTMAIL_ENTRYID])) {
-				$sentFolder = mapi_msgstore_openentry($store, $msgstoreProps[PR_IPM_SENTMAIL_ENTRYID]);
+			$sentFolder = empty($validIds) ? false : $this->openSentItemsFolder($store);
+			if ($sentFolder !== false) {
 				$table = mapi_folder_getcontentstable($sentFolder, MAPI_DEFERRED_ERRORS);
 
 				$subRestrictions = [];
@@ -244,12 +271,25 @@ class MailListModule extends ListModule {
 				}
 				mapi_table_restrict($table, [RES_OR, $subRestrictions], TBL_BATCH);
 
-				$rows = mapi_table_queryallrows($table, [PR_CONVERSATION_ID]);
+				$rows = mapi_table_queryallrows($table, [PR_CONVERSATION_ID, PR_SENSITIVITY]);
 				foreach ($rows as $row) {
-					if (isset($row[PR_CONVERSATION_ID])) {
-						$id = bin2hex((string) $row[PR_CONVERSATION_ID]);
-						$counts[$id] = ($counts[$id] ?? 0) + 1;
+					if (!isset($row[PR_CONVERSATION_ID])) {
+						continue;
 					}
+
+					// getConversationItems() removes private items from the
+					// conversation, so they must not be counted here either:
+					// the count is what the conversation header announces.
+					$props = [];
+					if (isset($row[PR_SENSITIVITY])) {
+						$props['sensitivity'] = $row[PR_SENSITIVITY];
+					}
+					if ($this->checkPrivateItem(['props' => $props])) {
+						continue;
+					}
+
+					$id = bin2hex((string) $row[PR_CONVERSATION_ID]);
+					$counts[$id] = ($counts[$id] ?? 0) + 1;
 				}
 			}
 		}
@@ -288,9 +328,9 @@ class MailListModule extends ListModule {
 			];
 
 			$folders = [];
-			$msgstoreProps = mapi_getprops($store, [PR_IPM_SENTMAIL_ENTRYID]);
-			if (isset($msgstoreProps[PR_IPM_SENTMAIL_ENTRYID])) {
-				$folders['sent_items'] = mapi_msgstore_openentry($store, $msgstoreProps[PR_IPM_SENTMAIL_ENTRYID]);
+			$sentFolder = $this->openSentItemsFolder($store);
+			if ($sentFolder !== false) {
+				$folders['sent_items'] = $sentFolder;
 			}
 			// The mail list already contains the inbox part of a conversation,
 			// but callers without that context (e.g. the search results


### PR DESCRIPTION
The conversation view only ever groups the inbox of the user's own mailbox. Open the inbox of a shared mailbox and the list stays flat, no matter how the conversation settings are set — while a search inside that very same mailbox does fold its results into conversations, so the same mailbox behaves two different ways depending on how you look at it.