### PR TITLE
fix: a folder in a shared mailbox cannot be deleted from its Deleted Items

### DIFF
--- a/client/zarafa/hierarchy/data/MAPIFolderRecord.js
+++ b/client/zarafa/hierarchy/data/MAPIFolderRecord.js
@@ -335,26 +335,19 @@ Zarafa.hierarchy.data.MAPIFolderRecord = Ext.extend(Zarafa.core.data.IPFRecord, 
 	 */
 	isInDeletedItems: function()
 	{
-		var mapiStore = this.getMAPIStore();
-		if(mapiStore){
-			if(mapiStore.isDefaultStore()) {
-				var parentFolder = this.getParentFolder();
-				if (!parentFolder || parentFolder.isIPMSubTree()) {
-					// If there is no parent folder, or the parent is the subtree,
-					// then the item is definitely not in the deleted items.
-					return false;
-				} else if (parentFolder.isSpecialFolder('wastebasket') || parentFolder.isSpecialFolder('junk')) {
-					// The item is in the wastebasker or junk folder.
-					// It is considered to be deleted.
-					return true;
-				} else {
-					// Perhaps the parent is inside the deleted items?
-					return parentFolder.isInDeletedItems();
-				}
-			}
+		var parentFolder = this.getParentFolder();
+		if (!parentFolder || parentFolder.isIPMSubTree()) {
+			// If there is no parent folder, or the parent is the subtree,
+			// then the item is definitely not in the deleted items.
+			return false;
+		} else if (parentFolder.isSpecialFolder('wastebasket') || parentFolder.isSpecialFolder('junk')) {
+			// The item is in the wastebasker or junk folder.
+			// It is considered to be deleted.
+			return true;
+		} else {
+			// Perhaps the parent is inside the deleted items?
+			return parentFolder.isInDeletedItems();
 		}
-
-		return false;
 	},
 
 	/**


### PR DESCRIPTION
### Problem

Create a folder in a shared mailbox, delete it so it lands in that mailbox's Deleted Items, then delete it from there. It is not deleted: it comes back renamed to `name (2)`, and deleting it again gives `name (3)`. The same three steps in the user's own mailbox work correctly.

### Cause

`MAPIFolderRecord#isInDeletedItems()` ran its whole parent walk inside `if (mapiStore.isDefaultStore())`, with a bare `return false` outside it. `isDefaultStore()` compares `mdb_provider` against `ZARAFA_SERVICE_GUID`, so for a shared mailbox (`ZARAFA_STORE_DELEGATE_GUID`) the method returned `false` unconditionally, including for a folder sitting directly in that store's Deleted Items.

`Zarafa.hierarchy.ui.ContextMenu#onContextItemDeleteFolder()` uses that predicate to choose between `store.remove(record)` and `record.moveTo(wastebasket)`, so the delete became a move. With `delegate_wastebasket_style` set to `4` the destination is the shared store's own wastebasket, which is the folder's current parent, so `Operations::copyFolder()` moves the folder into the folder it already lives in. `mapi_folder_copyfolder()` answers that with `MAPI_E_COLLISION` on the display name, and the handler asks `checkFolderNameConflict()` for a free name and retries the move, which renames the folder in place. With the default style `8` the destination is instead the delegate's own Deleted Items, so the same wrong predicate moves a shared folder out of the shared mailbox and into the user's personal one.

The public store case had already been worked around at the call site, which is why only shared mailboxes still reached this: `onContextItemDeleteFolder` reads `isInDeletedItems() || getMAPIStore().isPublicStore()`.

### Verification

Checked against a real gromox delegate store, with the shared mailbox granted full rights on Top of Information Store and Deleted Items, by driving the shipped `Operations` methods directly:

```
now in Trash as              : ProbeDel
parent == store wastebasket  : YES
before : copyFolder(move) -> true, the folder still exists as "ProbeDel (2)"
after  : deleteFolder     -> true, Trash now holds (nothing)
```

And the predicate itself, running the real `isInDeletedItems`, `isSpecialFolder`, `getParentFolder` and `EntryId.compareEntryIds` sources against entryids read off that same server. Before the change two cases are wrong, both of them shared-store cases; after it all seven are correct:

| case | before | after |
| --- | --- | --- |
| own store, folder in the Trash | true | true |
| own store, the Trash itself | false | false |
| shared store, folder in the shared Trash | **false** | true |
| shared store, folder nested below that one | **false** | true |
| shared store, folder under the subtree | false | false |
| shared store, the shared Trash itself | false | false |
| public store, folder under the subtree | false | false |