### PR TITLE
fix: declining one occurrence of a series briefly removes a different one

### DIFF
--- a/client/zarafa/calendar/AppointmentStore.js
+++ b/client/zarafa/calendar/AppointmentStore.js
@@ -53,6 +53,37 @@ Zarafa.calendar.AppointmentStore = Ext.extend(Zarafa.core.data.ListModuleStore, 
 	},
 
 	/**
+	 * Obtain the {@link Zarafa.calendar.AppointmentRecord record} which a notification
+	 * refers to. Every occurrence of a series carries the entryid of the series, and a
+	 * notification carries no basedate, so an entryid can match several records here.
+	 *
+	 * @param {Object} item The notification item, containing at least an entryid
+	 * @return {Zarafa.calendar.AppointmentRecord} The record, undefined when the store
+	 * does not hold it, or false when the entryid matches more than one occurrence.
+	 * @protected
+	 */
+	getRecordFromNotification: function(item)
+	{
+		var matches = [];
+
+		this.each(function(record) {
+			if (Zarafa.core.EntryId.compareEntryIds(record.get('entryid'), item.entryid)) {
+				matches.push(record);
+			}
+		});
+
+		if (matches.length < 2) {
+			return matches[0];
+		}
+
+		// The notification names the series, so which occurrence it is about cannot
+		// be determined. Reload rather than apply it to one of them.
+		this.reload();
+
+		return false;
+	},
+
+	/**
 	 * Event handler fired by the {@link Ext.data.Store} when a record is being removed
 	 * from the store. This adds a special case to the default behavior of the {@link Ext.data.Store#destroyRecord}
 	 * especially for recurring appointments. When the appointment is recurring, and no basedate is provided, we

--- a/client/zarafa/core/data/IPMNotificationResponseHandler.js
+++ b/client/zarafa/core/data/IPMNotificationResponseHandler.js
@@ -24,7 +24,14 @@ Zarafa.core.data.IPMNotificationResponseHandler = Ext.extend(Zarafa.core.data.Ab
 			for (var j = 0, len = recordData.length; j < len; j++) {
 				var item = recordData[j];
 
-				var record = this.store.getById(item.entryid);
+				var record = this.store.getRecordFromNotification(item);
+				if (record === false) {
+					// The store cannot tell which of its records the notification is
+					// about and handles it itself. Treating it as a new object here
+					// would add a second copy of an item the store already has.
+					continue;
+				}
+
 				if (!Ext.isDefined(record)) {
 					this.addNotification(Zarafa.core.data.Notifications.objectCreated, null, item);
 				} else {
@@ -51,7 +58,7 @@ Zarafa.core.data.IPMNotificationResponseHandler = Ext.extend(Zarafa.core.data.Ab
 		for (var i = 0, len = items.length; i < len; i++) {
 			var item = items[i];
 
-			var record = this.store.getById(item.entryid);
+			var record = this.store.getRecordFromNotification(item);
 			if (record) {
 				this.addNotification(Zarafa.core.data.Notifications.objectDeleted, record, item);
 			}

--- a/client/zarafa/core/data/MAPIStore.js
+++ b/client/zarafa/core/data/MAPIStore.js
@@ -420,6 +420,22 @@ Zarafa.core.data.MAPIStore = Ext.extend(Ext.data.GroupingStore, {
 	},
 
 	/**
+	 * Obtain the {@link Ext.data.Record record} which a notification refers to.
+	 * A notification identifies its subject by entryid alone, which is enough
+	 * whenever an entryid identifies at most one record in the store.
+	 *
+	 * @param {Object} item The notification item, containing at least an entryid
+	 * @return {Ext.data.Record} The record, or undefined when the store does not
+	 * hold it. Subclasses may return false to indicate that the notification
+	 * cannot be resolved and that they handle it themselves.
+	 * @protected
+	 */
+	getRecordFromNotification: function(item)
+	{
+		return this.getById(item.entryid);
+	},
+
+	/**
 	 * Compare a {@link Ext.data.Record#id ids} to determine if they are equal.
 	 * @param {String} a The first id to compare
 	 * @param {String} b The second id to compare


### PR DESCRIPTION
### Problem

Decline a single occurrence of a recurring meeting, for example from the month view. The occurrence that disappears is not the one that was declined but the first one of that series in the view. A reload puts it right, because the server did the correct thing all along: only the declined occurrence is gone from the calendar.

### Cause

Every occurrence of a series carries the entryid of the series and is told apart only by its `basedate`, which is why `AppointmentStore` keys its collection on entryid plus basedate rather than on the entryid alone.

A notification carries no basedate. Declining an occurrence of an appointment makes `Meetingrequest::doDecline()` report that the item was removed, so the item module fires `TABLE_DELETE`, and `ListNotifier` puts exactly two values into the `delete` item: `parent_entryid` and `entryid`. Nothing in it can name an occurrence.

`IPMNotificationResponseHandler` then resolved that item with `this.store.getById(item.entryid)`. For an occurrence, that misses the keyed lookup, so `Zarafa.core.data.MAPIStore#getById` fell through to its comparison against `Ext.data.Record#id` — which is the bare series entryid on every occurrence — and answered with the first occurrence in the store. The `objectDeleted` notification was applied to that record, which is the appointment that vanishes from the view.

### Fix

Resolve a notification through a store method rather than through `getById`. `Zarafa.core.data.MAPIStore#getRecordFromNotification()` keeps the existing lookup, so nothing changes for stores whose entryids identify one record each.

`Zarafa.calendar.AppointmentStore` overrides it: it collects every record matching the entryid, returns the record when there is exactly one, and when there is more than one it reloads instead of choosing between them. The notification handler skips the item in that case, because passing it on as an unknown record would take the `objectCreated` path and add a second copy of an item the store already holds.

The cost is one extra list request whenever a series notification arrives, and in exchange no appointment is ever changed on a guess. Carrying the basedate in the notification would avoid that request, and is worth doing separately: this lookup has to be safe regardless, because a notification about someone else's change will never carry one.

### Verification

Against a real gromox backend, using a seeded recurring meeting whose occurrences all share one entryid, declining the third of five over the JSON API removes exactly the third one server-side. So the server is not at fault and the notification is what misleads the client.

The client lookup was then exercised on its own, assembled out of the shipped sources — Ext's `MixedCollection#add`, `#key`, `#replace` and `Store#getById`, plus `AppointmentStore#getRecordKey`, `MAPIStore#getById`, `MAPIStore#idComparison` and `EntryId.compareEntryIds` — over a store built from the entryid and basedates measured on that server:

```
before : the lookup resolves to occurrence #1 (basedate 1787011200), declined was #3
after  : nothing, the store handles it itself (and reloads)
both   : a non-recurring appointment still resolves by entryid