### PR TITLE
oof: store a subject when out of office is turned on without one

### DIFF
--- a/client/zarafa/mail/settings/SettingsOofWidget.js
+++ b/client/zarafa/mail/settings/SettingsOofWidget.js
@@ -592,9 +592,10 @@ Zarafa.mail.settings.SettingsOofWidget = Ext.extend(Zarafa.settings.ui.SettingsW
 	 */
 	updateSettings: function()
 	{
-		// We must either set the requested subject, or the default subject
-		var intsubject = this.intSubjectField.getValue() || this.intSubjectField.emptyText;
-		var extsubject = this.extSubjectField.getValue() || this.extSubjectField.emptyText;
+		// We must either set the requested subject, or the default subject.
+		// A subject of nothing but spaces is as empty as no subject at all.
+		var intsubject = this.intSubjectField.getValue().trim() || this.intSubjectField.emptyText;
+		var extsubject = this.extSubjectField.getValue().trim() || this.extSubjectField.emptyText;
 
 		// We must either set the requested body, or the default body
 		var intbody = this.intBodyField.getValue() || this.intBodyField.emptyText;

--- a/server/includes/modules/class.outofofficesettingsmodule.php
+++ b/server/includes/modules/class.outofofficesettingsmodule.php
@@ -169,6 +169,26 @@ class OutOfOfficeSettingsModule extends Module {
 		if ($oofSet && isset($oofSettings['from']) && intval($oofSettings['from']) > time()) {
 			$props[$this->properties['set']] = 2;
 		}
+		// A reply carrying no subject at all reaches the sender as a blank line in
+		// their mailbox, so make sure a subject is stored whenever out of office
+		// is on. The client offers the same default in the settings form, but it
+		// is not the only way these properties are written.
+		foreach (['internal_subject', 'external_subject'] as $subject) {
+			$tag = $this->properties[$subject];
+
+			if (array_key_exists($tag, $props)) {
+				if (trim((string) $props[$tag]) === '') {
+					$props[$tag] = _('Out of Office');
+				}
+			}
+			elseif ($oofSet) {
+				$stored = mapi_getprops($store, [$tag]);
+				if (trim((string) ($stored[$tag] ?? '')) === '') {
+					$props[$tag] = _('Out of Office');
+				}
+			}
+		}
+
 		if (!empty($props)) {
 			mapi_setprops($store, $props);
 			mapi_savechanges($store);


### PR DESCRIPTION
### Problem

Out of office can be turned on with no subject, and the automatic reply then reaches the sender with a blank subject line. Read back off a store after saving that state, both subject properties are empty strings while out of office is on:

```
PR_EC_OUTOFOFFICE         : 1
PR_EC_OUTOFOFFICE_SUBJECT : "" (len 0)
PR_EC_EXTERNAL_SUBJECT    : "" (len 0)
```

### Cause

The settings form does carry a default — `emptyText` and `defaultValue` of `_('Out of Office')` on both subject fields — but it only substitutes it inside `SettingsOofWidget#updateSettings()`. That covers the one path through the form and nothing else, and because the check is a plain `||` on the field value, a subject consisting only of spaces passes it. `OutOfOfficeSettingsModule#saveOofSettings()` writes whatever properties it is handed, so an empty subject is stored as an empty subject.

### Fix

Default the subject in `saveOofSettings()`, which is the one place every write to these properties passes through in this application. Two cases are covered: a request that carries a blank subject, and out of office being switched on while the stored subject is blank. A subject that is actually filled in is never touched, and no subject is invented while out of office is off.

The form additionally trims the value before falling back to its default, so spaces no longer count as a subject.

The default is translated on both sides. The form sends the client catalogue's string, and `_()` on the server resolves through the bound text domain — running the shipped `Language` class against `de_DE.UTF-8` returns `Abwesend`, so a German user does not get an English subject stored on the fallback path either.

### Verification

Each case was saved through the module over the JSON API against a real store, then the store properties were read back:

| case | stored subject |
| --- | --- |
| empty subject, out of office on | `Out of Office` (internal and external) |
| subject of only spaces | `Out of Office` (internal and external) |
| a real subject, `Urlaub bis Freitag` | left untouched |
| out of office switched on, no subject sent, stored subject blank | `Out of Office` |
| out of office switched off, stored subject blank | left empty, nothing invented |
