### PR TITLE
fix: disabled-plugins lookup fails for every user on an LDAP login-name setup

### DIFF
--- a/grommunio.php
+++ b/grommunio.php
@@ -75,10 +75,15 @@ if (!WebAppAuthentication::isAuthenticated()) {
 
 // get the disabled plugin list from the config and admin-api
 $disabledPlugins = DISABLED_PLUGINS_LIST;
-$res = @json_decode(@file_get_contents(
-	ADMIN_API_DISABLEDPLUGINS_ENDPOINT . $GLOBALS["mapisession"]->getUserName(), false), true);
-if (isset($res['data'])) {
-	$disabledPlugins .= ';' . implode(';', $res['data']);
+// The endpoint resolves the domain out of the address, so it needs the SMTP
+// address rather than the name the user logged on with.
+$adminApiUser = $GLOBALS["mapisession"]->getSMTPAddress() ?: $GLOBALS["mapisession"]->getEmailAddress();
+if ($adminApiUser) {
+	$res = @json_decode(@file_get_contents(
+		ADMIN_API_DISABLEDPLUGINS_ENDPOINT . urlencode($adminApiUser), false), true);
+	if (isset($res['data'])) {
+		$disabledPlugins .= ';' . implode(';', $res['data']);
+	}
 }
 
 // Instantiate Plugin Manager

--- a/index.php
+++ b/index.php
@@ -144,10 +144,15 @@ if (isset($result['ldap']) && $result['ldap']) {
 
 // get the disabled plugin list from the config and admin-api
 $disabledPlugins = DISABLED_PLUGINS_LIST;
-$res = @json_decode(@file_get_contents(
-	ADMIN_API_DISABLEDPLUGINS_ENDPOINT . $GLOBALS["mapisession"]->getUserName(), false), true);
-if (isset($res['data'])) {
-	$disabledPlugins .= ';' . implode(';', $res['data']);
+// The endpoint resolves the domain out of the address, so it needs the SMTP
+// address rather than the name the user logged on with.
+$adminApiUser = $GLOBALS["mapisession"]->getSMTPAddress() ?: $GLOBALS["mapisession"]->getEmailAddress();
+if ($adminApiUser) {
+	$res = @json_decode(@file_get_contents(
+		ADMIN_API_DISABLEDPLUGINS_ENDPOINT . urlencode($adminApiUser), false), true);
+	if (isset($res['data'])) {
+		$disabledPlugins .= ';' . implode(';', $res['data']);
+	}
 }
 
 // Instantiate Plugin Manager

--- a/server/includes/load.php
+++ b/server/includes/load.php
@@ -22,10 +22,15 @@ if (!WebAppAuthentication::isAuthenticated()) {
 
 // get the disabled plugin list from the config and admin-api
 $disabledPlugins = DISABLED_PLUGINS_LIST;
-$res = @json_decode(@file_get_contents(
-	ADMIN_API_DISABLEDPLUGINS_ENDPOINT . $GLOBALS["mapisession"]->getUserName(), false), true);
-if (isset($res['data'])) {
-	$disabledPlugins .= ';' . implode(';', $res['data']);
+// The endpoint resolves the domain out of the address, so it needs the SMTP
+// address rather than the name the user logged on with.
+$adminApiUser = $GLOBALS["mapisession"]->getSMTPAddress() ?: $GLOBALS["mapisession"]->getEmailAddress();
+if ($adminApiUser) {
+	$res = @json_decode(@file_get_contents(
+		ADMIN_API_DISABLEDPLUGINS_ENDPOINT . urlencode($adminApiUser), false), true);
+	if (isset($res['data'])) {
+		$disabledPlugins .= ';' . implode(';', $res['data']);
+	}
 }
 
 // Instantiate Plugin Manager


### PR DESCRIPTION
### Problem

164e60d23 asks admin-api which plugins are disabled for the current user, and passes `$GLOBALS["mapisession"]->getUserName()`. That method returns the name that was handed to `logon()` — its own docblock says "equal to username passed in logon()" — which on an LDAP-backed installation is whatever the directory uses for logins. On ours that is the sAMAccountName, e.g. `samseiz`.

The endpoint needs an address, not a login name. `getDisabledPluginsOfUser()` in admin-api (`endpoints/misc.py`) rejects anything without an `@` before it does anything else, then resolves the domain with `username.split("@")[1]`:

```python
if "@" not in username:
    return jsonify(message="Invalid username"), 400
domain = Domains.query.filter(Domains.domainname == username.split("@")[1]).first()
```

So on such a setup every one of the three call sites logs a 400 on every page load, and no plugin the administrator disabled is ever applied. Nothing visibly breaks in the client, because the response is discarded by the `isset($res['data'])` guard and `$disabledPlugins` falls back to the configured list — which is what makes it easy to miss. Observed on grommunio Web 3.19.124.gf26f375c3 as `GET /api/v1/disabledPluginsOfUser?username=samseiz from ::1 -> 400 '{"message":"Invalid username"}'`.

A related spot assumes the same thing: the `domainname` cookie in `class.webappauthentication.php` is only set when `explode('@', $username)` yields two parts, so it is absent on these installations too. I have left that alone here.

### What this changes

All three call sites — `index.php`, `grommunio.php` and `server/includes/load.php` — now pass `getSMTPAddress()`, falling back to `getEmailAddress()`. That is the same idiom `class.itemmodule.php` already uses when it needs the current user's address. The request is skipped entirely when neither answers, since it could only produce the 400 above, and the value is urlencoded because it is going into a query string.

### Verification

PHP 8.2 lint clean on all three files. I also ran the old and the new expression side by side against a model of the admin-api check, with a stub session, to confirm the control arm reproduces the failure and the patched arm does not:

| case | old | new |
|---|---|---|
| sAMAccountName login | 400 Invalid username | 200 domain resolved |
| login with full address | 200 domain resolved | 200 domain resolved |
| no SMTP address, e-mail present | 400 Invalid username | 200 domain resolved |
| neither available | 400 Invalid username | no request made |
| address containing a plus | 400 Invalid username | 200 domain resolved |

That is a model of the endpoint rather than the endpoint itself, so it demonstrates the identifier that gets sent, not an end-to-end round trip against a live admin-api.

### Open question

`getSMTPAddress()` goes through `retrieveUserData()`, which issues two `mapi_getprops` calls and among other things fetches `PR_EMS_AB_THUMBNAIL_PHOTO`. It is memoised per request, but on the `server/includes/load.php` path it is not otherwise warm — the `getFullName()` call in `class.webappauthentication.php` only runs on a fresh logon — so this pulls user data earlier than before on requests that would not have needed it. If you would rather not pay that on every request, a getter that fetches only `PR_SMTP_ADDRESS` would avoid it, and I am happy to change it to that instead.