### PR TITLE
fix: closing a shared mailbox fails on a stale favourite, and deletes unrelated ones

### DIFF
--- a/server/includes/modules/class.hierarchymodule.php
+++ b/server/includes/modules/class.hierarchymodule.php
@@ -954,14 +954,6 @@ class HierarchyModule extends Module {
 							$GLOBALS["bus"]->notify(bin2hex((string) $message[PR_ENTRYID]), OBJECT_SAVE, $message);
 						}
 					}
-					elseif (isset($message[PR_WLINK_STORE_ENTRYID])) {
-						$storeObj = $GLOBALS["mapisession"]->openMessageStore($message[PR_WLINK_STORE_ENTRYID]);
-						$storeProps = mapi_getprops($storeObj, [PR_ENTRYID]);
-						if ($GLOBALS['entryid']->compareEntryIds($message[PR_WLINK_ENTRYID], $storeProps[PR_ENTRYID])) {
-							mapi_folder_deletemessages($commonViewsFolder, [$message[PR_ENTRYID]]);
-							$this->sendFeedback(true);
-						}
-					}
 				}
 			}
 		}


### PR DESCRIPTION
### Problem

Two defects in the same branch of `HierarchyModule::removeFromFavorite()`, both reachable by closing a shared mailbox.

**Closing fails outright** for a user who has a favourite pointing at a mailbox that can no longer be opened — deleted, renamed, or access withdrawn. The mailbox stays open and the message gives no hint of the cause:

```
"hresult_name": "MAPI_E_INVALID_PARAMETER",
"file": "class.hierarchymodule.php:959",
"display_message": "Could not close shared folder. (An invalid parameter was passed to a function or remote procedure call)"
```

**And closing one shared mailbox deletes the store-level favourites of the others.** Favourites are user data and there is no undo, so this is silent loss that looks unrelated to the action that caused it.

### Cause

The branch opened the store each favourite link points at, in order to compare the link against it:

```php
elseif (isset($message[PR_WLINK_STORE_ENTRYID])) {
    $storeObj = $GLOBALS["mapisession"]->openMessageStore($message[PR_WLINK_STORE_ENTRYID]);
    $storeProps = mapi_getprops($storeObj, [PR_ENTRYID]);
    if ($GLOBALS['entryid']->compareEntryIds($message[PR_WLINK_ENTRYID], $storeProps[PR_ENTRYID])) {
        mapi_folder_deletemessages($commonViewsFolder, [$message[PR_ENTRYID]]);
```

`MAPISession::openMessageStore()` returns `false` when the store cannot be opened — it logs the failure and swallows the exception — and this is the one call site that does not check, so the `false` reaches `mapi_getprops()` on line 959 and comes back as `MAPI_E_INVALID_PARAMETER`.

The comparison is the second defect. It matches the link's own `PR_WLINK_ENTRYID` against the store that same link points at, which only asks whether this is a store-level favourite; the mailbox actually being closed never enters into it. Every store-level favourite therefore matched, whichever mailbox was being closed.

### Fix

Drop the branch. Nothing is lost by removing it, because the branch directly above already deletes the links that belong to the mailbox being closed — both store-level and folder-level ones — by comparing against the entryid the caller passed:

```php
if (isset($message[$prop]) && $GLOBALS['entryid']->compareEntryIds($message[$prop], $entryid)) {
```

Closing a whole shared mailbox passes that store's entryid with `PR_WLINK_STORE_ENTRYID` as the property, so every favourite of that mailbox matches there. Closing a single shared folder passes the folder entryid with `PR_WLINK_ENTRYID`, which removes that folder's favourite and correctly leaves the mailbox's own favourite alone, since the mailbox stays open.

### Verification

Against a store, with a favourite whose target mailbox cannot be opened, a favourite for the mailbox being closed, and an unrelated favourite for a third mailbox:

| | before | after |
| --- | --- | --- |
| close with the unopenable favourite present | `MAPI_E_INVALID_PARAMETER` at :959 | succeeds |
| favourite of the mailbox being closed | removed | removed |
| favourite of an unrelated mailbox | **deleted** | survives |
| the unopenable link | untouched | untouched |

The second row is the one that would catch this going too far: the favourites that should be cleaned up still are.

### Note

Because the exception aborted the loop partway, users who have hit this repeatedly may already have lost favourites for other mailboxes — the deletions that happened before the failing link were committed. That is not recoverable from the client side.