### PR TITLE
fix: attach an attachment dragged from another grommunio Web tab, and prompt in the right window

### DIFF
--- a/client/zarafa/common/attachment/AttachmentDragDrop.js
+++ b/client/zarafa/common/attachment/AttachmentDragDrop.js
@@ -123,13 +123,13 @@ Zarafa.common.attachment.AttachmentDragDrop = {
 			return undefined;
 		}
 
-		var name = String(payload.name).replace(/[\r\n]+/g, ' ').replace(/^.*[\\\/]/, '');
+		var name = String(payload.name).replace(/[\r\n]+/g, ' ').replace(/^.*[\\/]/, '');
 		if (Ext.isEmpty(name)) {
 			return undefined;
 		}
 
 		var mimeType = String(payload.type || '').split(';')[0].trim();
-		if (!/^[\w.+-]+\/[\w.+-]+$/.test(mimeType)) {
+		if (!(/^[\w.+-]+\/[\w.+-]+$/).test(mimeType)) {
 			mimeType = this.defaultMimeType;
 		}
 

--- a/client/zarafa/common/attachment/AttachmentDragDrop.js
+++ b/client/zarafa/common/attachment/AttachmentDragDrop.js
@@ -1,0 +1,182 @@
+Ext.namespace('Zarafa.common.attachment');
+
+/**
+ * @class Zarafa.common.attachment.AttachmentDragDrop
+ * Reads the payload that {@link Zarafa.common.ui.messagepanel.AttachmentLinks}
+ * puts on a drag, so an attachment dragged out of a message can be dropped back
+ * into grommunio-web in another browser tab or window.
+ * @singleton
+ */
+Zarafa.common.attachment.AttachmentDragDrop = {
+	/**
+	 * The MIME type under which a dragged attachment carries its bytes.
+	 * @property
+	 * @type String
+	 */
+	payloadType: 'application/x-grommunio-attachment',
+
+	/**
+	 * The MIME type applied when the payload names none, or names an invalid one.
+	 * @property
+	 * @type String
+	 */
+	defaultMimeType: 'application/octet-stream',
+
+	/**
+	 * @param {DataTransfer} dataTransfer The dataTransfer of a drag event
+	 * @return {Boolean} True if the drag advertises an attachment payload
+	 */
+	hasPayload: function(dataTransfer)
+	{
+		if (!dataTransfer || !dataTransfer.types) {
+			return false;
+		}
+
+		return Array.prototype.indexOf.call(dataTransfer.types, this.payloadType) >= 0;
+	},
+
+	/**
+	 * Builds a {@link FileList} from the attachment payload of a drag.
+	 *
+	 * The list is built with the constructors of targetWindow because
+	 * {@link Zarafa.core.data.IPMAttachmentStore#uploadFiles} accepts a FileList
+	 * only when it is an instance of the one belonging to the window it runs in.
+	 *
+	 * @param {DataTransfer} dataTransfer The dataTransfer of a drag event
+	 * @param {Object} targetWindow The browser window the files are uploaded from
+	 * @return {FileList} The dragged files, or undefined when there are none
+	 */
+	getFileList: function(dataTransfer, targetWindow)
+	{
+		if (!this.hasPayload(dataTransfer)) {
+			return undefined;
+		}
+
+		var payloads = this.parsePayload(dataTransfer);
+		if (Ext.isEmpty(payloads)) {
+			return undefined;
+		}
+
+		var win = targetWindow || window;
+		if (!Ext.isFunction(win.File) || !Ext.isFunction(win.DataTransfer)) {
+			return undefined;
+		}
+
+		var maxSize = this.getMaxSize();
+		var builder = new win.DataTransfer();
+		var count = 0;
+
+		for (var i = 0, len = payloads.length; i < len; i++) {
+			var file = this.buildFile(payloads[i], win, maxSize);
+			if (file) {
+				builder.items.add(file);
+				count++;
+			}
+		}
+
+		return count > 0 ? builder.files : undefined;
+	},
+
+	/**
+	 * @param {DataTransfer} dataTransfer The dataTransfer of a drag event
+	 * @return {Array} The payload entries, empty when the drag carries none
+	 * @private
+	 */
+	parsePayload: function(dataTransfer)
+	{
+		var raw;
+		try {
+			raw = dataTransfer.getData(this.payloadType);
+		} catch (e) {
+			return [];
+		}
+
+		if (Ext.isEmpty(raw)) {
+			return [];
+		}
+
+		var payloads;
+		try {
+			payloads = JSON.parse(raw);
+		} catch (e) {
+			return [];
+		}
+
+		return Ext.isArray(payloads) ? payloads : [payloads];
+	},
+
+	/**
+	 * Turns one payload entry into a {@link File} of the given window. The
+	 * payload reaches us through the drag and is not trusted: the name is
+	 * reduced to its basename, the MIME type must be well formed, and the
+	 * decoded size is held to the server's embed limit.
+	 *
+	 * @param {Object} payload One payload entry, holding name, type and base64 data
+	 * @param {Object} win The browser window whose File constructor is used
+	 * @param {Number} maxSize The largest accepted size in bytes, 0 for no limit
+	 * @return {File} The file, or undefined when the entry is unusable
+	 * @private
+	 */
+	buildFile: function(payload, win, maxSize)
+	{
+		if (!payload || Ext.isEmpty(payload.name) || !Ext.isString(payload.data)) {
+			return undefined;
+		}
+
+		var name = String(payload.name).replace(/[\r\n]+/g, ' ').replace(/^.*[\\\/]/, '');
+		if (Ext.isEmpty(name)) {
+			return undefined;
+		}
+
+		var mimeType = String(payload.type || '').split(';')[0].trim();
+		if (!/^[\w.+-]+\/[\w.+-]+$/.test(mimeType)) {
+			mimeType = this.defaultMimeType;
+		}
+
+		var bytes = this.decodeBase64(payload.data, win);
+		if (!bytes || (maxSize > 0 && bytes.length > maxSize)) {
+			return undefined;
+		}
+
+		try {
+			return new win.File([bytes], name, { type: mimeType });
+		} catch (e) {
+			return undefined;
+		}
+	},
+
+	/**
+	 * @param {String} base64 The base64 encoded file content
+	 * @param {Object} win The browser window whose Uint8Array is used
+	 * @return {Uint8Array} The decoded bytes, or undefined when undecodable
+	 * @private
+	 */
+	decodeBase64: function(base64, win)
+	{
+		try {
+			var binary = win.atob(String(base64));
+			var bytes = new win.Uint8Array(binary.length);
+			for (var i = 0, len = binary.length; i < len; i++) {
+				bytes[i] = binary.charCodeAt(i);
+			}
+
+			return bytes;
+		} catch (e) {
+			return undefined;
+		}
+	},
+
+	/**
+	 * @return {Number} The largest accepted payload size in bytes, 0 for no limit
+	 * @private
+	 */
+	getMaxSize: function()
+	{
+		var serverConfig = container.getServerConfig();
+		if (serverConfig && Ext.isFunction(serverConfig.getAttachmentDragOutMaxSize)) {
+			return serverConfig.getAttachmentDragOutMaxSize();
+		}
+
+		return 0;
+	}
+};

--- a/client/zarafa/common/attachment/ui/AttachmentField.js
+++ b/client/zarafa/common/attachment/ui/AttachmentField.js
@@ -115,7 +115,18 @@ Zarafa.common.attachment.ui.AttachmentField = Ext.extend(Zarafa.common.ui.BoxFie
 
 		this.wrap.removeClass(this.wrapFocusClass);
 
-		var files = event.browserEvent.target.files || event.browserEvent.dataTransfer.files;
+		var dataTransfer = event.browserEvent.dataTransfer;
+		var files = event.browserEvent.target.files || dataTransfer.files;
+
+		// A drag started on an attachment in another grommunio Web tab or window
+		// carries its bytes as a payload and leaves the FileList empty.
+		if (!files || files.length === 0) {
+			var ownerWindow = Zarafa.core.BrowserWindowMgr.activateOwnerWindow(this.wrap);
+			files = Zarafa.common.attachment.AttachmentDragDrop.getFileList(dataTransfer, ownerWindow);
+			if (!files || files.length === 0) {
+				return;
+			}
+		}
 
 		// Test if the files can be uploaded, upload them if possible
 		if (this.boxStore.canUploadFiles(files, { container: this.recordComponentUpdaterPlugin.rootContainer.getEl() })) {

--- a/client/zarafa/common/form/TextArea.js
+++ b/client/zarafa/common/form/TextArea.js
@@ -43,7 +43,8 @@ Zarafa.common.form.TextArea = Ext.extend(Ext.form.TextArea, {
 	onFileDragOver: function(e)
 	{
 		var dt = e.browserEvent.dataTransfer;
-		if (dt && (Array.prototype.indexOf.call(dt.types, 'Files') >= 0 || dt.files.length > 0)) {
+		if (dt && (Array.prototype.indexOf.call(dt.types, 'Files') >= 0 || dt.files.length > 0 ||
+			Zarafa.common.attachment.AttachmentDragDrop.hasPayload(dt))) {
 			e.preventDefault();
 		}
 	},
@@ -57,14 +58,26 @@ Zarafa.common.form.TextArea = Ext.extend(Ext.form.TextArea, {
 	 */
 	onFileDrop: function(e)
 	{
+		var dragDrop = Zarafa.common.attachment.AttachmentDragDrop;
 		var dt = e.browserEvent.dataTransfer;
-		if (!dt || (Array.prototype.indexOf.call(dt.types, 'Files') < 0 && dt.files.length === 0)) {
+		if (!dt || (Array.prototype.indexOf.call(dt.types, 'Files') < 0 && dt.files.length === 0 &&
+			!dragDrop.hasPayload(dt))) {
 			return;
 		}
 
 		e.preventDefault();
 
+		// A drop does not focus its window, so activate the one this field is
+		// rendered in or the confirmation below opens in the main window.
+		var ownerWindow = Zarafa.core.BrowserWindowMgr.activateOwnerWindow(this.el);
+
+		// A drag started on an attachment in another grommunio Web tab or window
+		// carries its bytes as a payload and leaves the FileList empty.
 		var files = dt.files;
+		if (!files || files.length === 0) {
+			files = dragDrop.getFileList(dt, ownerWindow);
+		}
+
 		if (!files || files.length === 0) {
 			return;
 		}
@@ -79,10 +92,6 @@ Zarafa.common.form.TextArea = Ext.extend(Ext.form.TextArea, {
 
 		var self = this;
 		var filesSnapshot = files; // keep a reference before the event is recycled
-
-		// A drop does not focus its window, so activate the one this field is
-		// rendered in or the confirmation opens in the main window.
-		Zarafa.core.BrowserWindowMgr.activateOwnerWindow(this.el);
 
 		Ext.MessageBox.confirm(
 			_('Add as attachment?'),

--- a/client/zarafa/common/form/TextArea.js
+++ b/client/zarafa/common/form/TextArea.js
@@ -80,6 +80,10 @@ Zarafa.common.form.TextArea = Ext.extend(Ext.form.TextArea, {
 		var self = this;
 		var filesSnapshot = files; // keep a reference before the event is recycled
 
+		// A drop does not focus its window, so activate the one this field is
+		// rendered in or the confirmation opens in the main window.
+		Zarafa.core.BrowserWindowMgr.activateOwnerWindow(this.el);
+
 		Ext.MessageBox.confirm(
 			_('Add as attachment?'),
 			_('The following files cannot be embedded in the message body. Add them as attachments instead?') +

--- a/client/zarafa/common/ui/HtmlEditor.js
+++ b/client/zarafa/common/ui/HtmlEditor.js
@@ -150,7 +150,22 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 							return;
 						}
 
+						// Activate the window this editor is rendered in: a drop does
+						// not focus its window, and the FileList below has to be built
+						// with its constructor.
+						var editorWindow = Zarafa.core.BrowserWindowMgr.activateOwnerWindow(self.getEl()) || window;
+
+						// A drag started on an attachment in another grommunio Web tab
+						// or window carries its bytes as a payload and leaves the
+						// FileList empty, so rebuild the files from that payload.
+						var dragDrop = Zarafa.common.attachment.AttachmentDragDrop;
+						var fromPayload = false;
 						var files = dt.files;
+						if ((!files || files.length === 0) && dragDrop.hasPayload(dt)) {
+							files = dragDrop.getFileList(dt, editorWindow);
+							fromPayload = true;
+						}
+
 						if (!files || files.length === 0) {
 							return;
 						}
@@ -161,8 +176,10 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 						var nonEmbeddable = [];
 						var hasEmbeddable = false;
 						for (var i = 0; i < files.length; i++) {
+							// TinyMCE embeds images from the drop's own FileList, which a
+							// payload drag does not carry, so those are attached as well.
 							var ext = (files[i].name.split('.').pop() || '').toLowerCase();
-							if (imageExts.indexOf(ext) < 0) {
+							if (fromPayload || imageExts.indexOf(ext) < 0) {
 								nonEmbeddable.push(files[i]);
 							} else {
 								hasEmbeddable = true;
@@ -212,14 +229,10 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 						// so it is uploaded/attached exactly like a drop on the Attachments
 						// field would be.
 						//
-						// The FileList has to be built with the constructor of the window
-						// this editor is rendered in: a dialog opened in its own window has
-						// its own FileList, and an object built elsewhere would fail that
-						// instanceof check and be attached as a bare filename.
-						//
-						// Activating that window also makes the confirmation below open
-						// next to the editor, because a drop does not focus its window.
-						var editorWindow = Zarafa.core.BrowserWindowMgr.activateOwnerWindow(self.getEl()) || window;
+						// It is built with the constructor of editorWindow: a dialog
+						// opened in its own window has its own FileList, and an object
+						// built elsewhere would fail that instanceof check and be
+						// attached as a bare filename.
 						var uploadFileList = nonEmbeddable;
 						if (Ext.isFunction(editorWindow.DataTransfer)) {
 							var fileListBuilder = new editorWindow.DataTransfer();

--- a/client/zarafa/common/ui/HtmlEditor.js
+++ b/client/zarafa/common/ui/HtmlEditor.js
@@ -213,14 +213,16 @@ Zarafa.common.ui.HtmlEditor = Ext.extend(Ext.ux.form.TinyMCETextArea, {
 						// field would be.
 						//
 						// The FileList has to be built with the constructor of the window
-						// uploadFiles() will check it against, which is the active browser
-						// window rather than necessarily this one: a dialog opened in its
-						// own window has its own FileList, and an object built here would
-						// fail that instanceof check and be attached as a bare filename.
-						var activeBrowserWindow = Zarafa.core.BrowserWindowMgr.getActive() || window;
+						// this editor is rendered in: a dialog opened in its own window has
+						// its own FileList, and an object built elsewhere would fail that
+						// instanceof check and be attached as a bare filename.
+						//
+						// Activating that window also makes the confirmation below open
+						// next to the editor, because a drop does not focus its window.
+						var editorWindow = Zarafa.core.BrowserWindowMgr.activateOwnerWindow(self.getEl()) || window;
 						var uploadFileList = nonEmbeddable;
-						if (Ext.isFunction(activeBrowserWindow.DataTransfer)) {
-							var fileListBuilder = new activeBrowserWindow.DataTransfer();
+						if (Ext.isFunction(editorWindow.DataTransfer)) {
+							var fileListBuilder = new editorWindow.DataTransfer();
 							nonEmbeddable.forEach(function(f) {
 								fileListBuilder.items.add(f);
 							});

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -146,24 +146,17 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 
 	/**
 	 * Returns whether the attachment bytes may be embedded in the drag
-	 * operation, which requires the server to allow it (see
-	 * ENABLE_ATTACHMENT_DRAG_OUT in config.php) and the browser to support it
-	 * (<tt>window.fetch</tt> and <tt>FileReader</tt>).
+	 * operation, which requires the browser to support <tt>window.fetch</tt>
+	 * and <tt>FileReader</tt>.
 	 *
-	 * This governs the {@link #attachmentDragOutType} payload only; it is not a
-	 * switch for dragging attachments as such. Dragging an attachment to the
-	 * operating system uses the <tt>DownloadURL</tt> type, needs no payload and
-	 * is always available.
+	 * This governs the {@link #attachmentDragOutType} payload only. Dragging an
+	 * attachment to the operating system uses the <tt>DownloadURL</tt> type and
+	 * needs no payload.
 	 * @return {Boolean} True if attachment payloads may be embedded in a drag
 	 * @private
 	 */
 	isDragOutEmbedEnabled: function()
 	{
-		var serverConfig = container.getServerConfig();
-		if (serverConfig && Ext.isFunction(serverConfig.isAttachmentDragOutEnabled) && !serverConfig.isAttachmentDragOutEnabled()) {
-			return false;
-		}
-
 		return Ext.isFunction(window.fetch) && typeof FileReader === 'function';
 	},
 

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -36,6 +36,9 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	 * reconstructs the file. The value is a JSON string of the form
 	 * <tt>{name, type, size, data}</tt> where <tt>data</tt> is the base64
 	 * encoded file content.
+	 *
+	 * Must match {@link Zarafa.common.attachment.AttachmentDragDrop#payloadType},
+	 * which reads the payload when the drop lands in grommunio Web itself.
 	 * @property {String}
 	 * @private
 	 */

--- a/client/zarafa/core/BrowserWindowMgr.js
+++ b/client/zarafa/core/BrowserWindowMgr.js
@@ -368,6 +368,27 @@ Zarafa.core.BrowserWindowMgr = Ext.extend(Ext.util.Observable, {
 	},
 
 	/**
+	 * Makes the browser window a component is rendered in the active one, so
+	 * dialogs raised from that component open next to it. Use this when acting
+	 * on an event which does not focus its window, such as a drop coming from
+	 * outside the browser.
+	 *
+	 * @param {Ext.Component/Ext.Element} component The component whose window must become active.
+	 * @return {Object} The browser window object owning the component.
+	 */
+	activateOwnerWindow: function(component)
+	{
+		var ownerWindow = this.getOwnerWindow(component) || window;
+		var windowName = ownerWindow.name;
+
+		if (windowName && windowName !== this.activeBrowserWindow && this.browserWindows.get(windowName)) {
+			this.setActive(windowName);
+		}
+
+		return ownerWindow;
+	},
+
+	/**
 	 * Event handler which is raised when browser window receives user focus.
 	 * This will make respective browser window active into {@link Zarafa.core.BrowserWindowMgr BrowserWindowMgr}.
 	 *

--- a/client/zarafa/core/data/ServerConfig.js
+++ b/client/zarafa/core/data/ServerConfig.js
@@ -69,18 +69,6 @@ Zarafa.core.data.ServerConfig = Ext.extend(Object, {
 	},
 
 	/**
-	 * @return {Boolean} True if the attachment bytes may be embedded in a drag
-	 * operation, so a cooperating web application can reconstruct the file on
-	 * drop (see ENABLE_ATTACHMENT_DRAG_OUT in config.php). This does not affect
-	 * dragging an attachment onto the operating system, which needs no embedded
-	 * bytes.
-	 */
-	isAttachmentDragOutEnabled: function()
-	{
-		return this.meta.enable_attachment_drag_out !== false;
-	},
-
-	/**
 	 * @return {Number} The maximum attachment size (in bytes) whose content is
 	 * embedded in a drag operation for the attachment drag-out feature (see
 	 * ATTACHMENT_DRAG_OUT_MAX_SIZE in config.php). Defaults to 25 MiB when the

--- a/config.php.dist
+++ b/config.php.dist
@@ -31,17 +31,9 @@
 	// Set to 'false' to disable the feature server-wide regardless of user settings.
 	define("ENABLE_CONVERSATION_VIEW", TRUE);
 
-	// Allow dragging attachments out of an opened e-mail directly into a
-	// cooperating web application's drop zone (the attachment bytes are embedded
-	// in the drag operation). Set to FALSE to disable that embedding server-wide.
-	// Dragging an attachment onto the operating system (file manager, desktop)
-	// needs no embedded bytes and remains available either way.
-	// Overrides defaults.php
-	//define("ENABLE_ATTACHMENT_DRAG_OUT", TRUE);
-
 	// Maximum attachment size (in bytes) whose content is embedded in the drag
-	// operation for ENABLE_ATTACHMENT_DRAG_OUT. Larger attachments are not
-	// embedded; they can still be dragged to the operating system. Default 25 MiB.
+	// operation. Larger attachments are not embedded; they can still be dragged
+	// to the operating system. Default 25 MiB.
 	// Overrides defaults.php
 	//define("ATTACHMENT_DRAG_OUT_MAX_SIZE", 26214400);
 

--- a/defaults.php
+++ b/defaults.php
@@ -44,23 +44,10 @@ if (!defined("ENABLE_FILE_PREVIEWER")) {
 	define("ENABLE_FILE_PREVIEWER", true);
 }
 
-// Allow dragging attachments out of an opened e-mail directly into a
-// cooperating web application's drop zone. The attachment bytes are embedded in
-// the drag operation so the receiving site can reconstruct the file without a
-// separate authenticated download. Set to false to disable that embedding.
-//
-// This does not switch off dragging attachments as such: dropping an attachment
-// onto the operating system (file manager, desktop) is done by handing the
-// browser the attachment's download URL, requires no embedded bytes and stays
-// available regardless of this setting.
-if (!defined("ENABLE_ATTACHMENT_DRAG_OUT")) {
-	define("ENABLE_ATTACHMENT_DRAG_OUT", true);
-}
-
 // Maximum attachment size (in bytes) whose content is embedded in the drag
-// operation for ENABLE_ATTACHMENT_DRAG_OUT. Larger attachments are not embedded
-// (to avoid excessive memory/bandwidth usage); they can still be dragged to the
-// operating system (file manager, desktop). Default: 25 MiB.
+// operation. Larger attachments are not embedded (to avoid excessive
+// memory/bandwidth usage); they can still be dragged to the operating system
+// (file manager, desktop). Default: 25 MiB.
 if (!defined("ATTACHMENT_DRAG_OUT_MAX_SIZE")) {
 	define("ATTACHMENT_DRAG_OUT_MAX_SIZE", 26214400);
 }

--- a/server/includes/templates/webclient.php
+++ b/server/includes/templates/webclient.php
@@ -14,7 +14,6 @@ $serverConfig = array_merge($serverConfig, [
 	'plugin_webappmanual_url' => PLUGIN_WEBAPPMANUAL_URL,
 	'enable_shared_rules' => ENABLE_SHARED_RULES,
 	'enable_conversation_view' => !defined('ENABLE_CONVERSATION_VIEW') || ENABLE_CONVERSATION_VIEW,
-	'enable_attachment_drag_out' => !defined('ENABLE_ATTACHMENT_DRAG_OUT') || ENABLE_ATTACHMENT_DRAG_OUT,
 	'attachment_drag_out_max_size' => defined('ATTACHMENT_DRAG_OUT_MAX_SIZE') ? (int) ATTACHMENT_DRAG_OUT_MAX_SIZE : 26214400,
 	'always_enabled_plugins' => $GLOBALS['PluginManager']->expandPluginList(ALWAYS_ENABLED_PLUGINS_LIST),
 	'enable_advanced_settings' => ENABLE_ADVANCED_SETTINGS ? true : false,


### PR DESCRIPTION
Three commits: one bug fix, one feature, one config removal.

## An attachment dragged between two grommunio Web tabs was dropped into nothing

Dragging an attachment out of an opened mail and into a new mail in a second tab did nothing at all. The same drag onto the operating system worked.

`AttachmentLinks` already puts the attachment on the drag under `application/x-grommunio-attachment`, as a JSON string holding name, type, size and the base64 content. That payload is self-contained and survives a drag between tabs and windows. Nothing read it: the type was written in one place and there was no `getData()` call on a `dataTransfer` anywhere in `client/zarafa`.

Every drop path took its files from `dataTransfer.files`, which only an operating-system drag populates. A drag started inside the browser cannot carry a synthetic `File`, so `HtmlEditor`, `AttachmentField` and `TextArea` all returned before doing anything.

`Zarafa.common.attachment.AttachmentDragDrop` now reads that payload and rebuilds a real `FileList`, and the three drop handlers fall back to it when `dataTransfer.files` is empty. The files are then attached through the same `uploadFiles()` path as an operating-system drop.

The payload arrives over a drag and is not trusted: the file name is reduced to its basename, the MIME type has to match `type/subtype` or becomes `application/octet-stream`, and the decoded length is held to `ATTACHMENT_DRAG_OUT_MAX_SIZE`.

Two details in the editor path are worth naming. The `FileList` has to be built with the constructor of the window the editor is rendered in, because `IPMAttachmentStore#uploadFiles()` checks it with `instanceof` and a list built in another window is silently treated as a list of bare filenames, giving a 0-byte attachment. And a payload drag is attached whole rather than split into embeddable images and the rest: TinyMCE embeds images from the drop's own `FileList`, which a payload drag does not carry, so an image classified as embeddable would have been dropped on the floor.

## The dropped-file prompt opened in the main window

Opening a mail in its own browser window, then dropping a file into the body, raised the confirmation in the main window instead.

`BrowserWindowMgr.setActive()` is what points `Ext.MessageBox` at a window, and it is driven by `onSeparateWindowFocus`. A drop coming from outside the browser does not focus the window it lands in, so `activeBrowserWindow` stayed `mainBrowserWindow` and the prompt rendered there.

`BrowserWindowMgr.activateOwnerWindow(component)` resolves the window a component is rendered in and makes it active. `HtmlEditor` and `TextArea` call it before prompting. This also corrects the window used to build the upload `FileList`, which was taken from `getActive()` and had the same problem.

## ENABLE_ATTACHMENT_DRAG_OUT is gone

Removed from `defaults.php`, `config.php.dist`, the `webclient.php` server config and `ServerConfig.js`; embedding the bytes is now unconditional. `ATTACHMENT_DRAG_OUT_MAX_SIZE` stays and still bounds what is embedded.

This also settles an inconsistency in the flag: it gated the embedded payload but not the `DownloadURL` path, so dragging to the operating system was never affected by it. I think that Web to Web Drag and drop should be a native feature so this is my personal reference. 