### PR TITLE
calendar: push the view restriction into the table load

### DIFF
--- a/server/includes/modules/class.appointmentlistmodule.php
+++ b/server/includes/modules/class.appointmentlistmodule.php
@@ -414,7 +414,10 @@ class AppointmentListModule extends ListModule {
 		try {
 			$folder = mapi_msgstore_openentry($store, $entryid);
 			$table = mapi_folder_getcontentstable($folder, MAPI_DEFERRED_ERRORS);
-			$calendaritems = mapi_table_queryallrows($table, $this->properties, $restriction);
+			// Restricting the table filters it while it loads; passing the
+			// restriction to queryallrows instead walks it row by row.
+			mapi_table_restrict($table, $restriction, TBL_BATCH);
+			$calendaritems = mapi_table_queryallrows($table, $this->properties);
 
 			return $this->processItems($calendaritems, $store, $entryid, $start, $end);
 		}


### PR DESCRIPTION
Opening a calendar view in a folder that holds a few thousand appointments takes most of a second, and nearly all of that time is spent in how the date restriction is applied rather than in reading the appointments that the view actually shows.

## What happens now

`AppointmentListModule::getCalendarItems()` builds the date restriction and passes it to `mapi_table_queryallrows()` as the third argument. In gromox that argument does not reach the table load: `zs_queryrows()` only pushes a restriction down for attachment, recipient, store and address-book tables, which it routes through `filter_rows()`. For a content table it takes a different branch and walks the table instead, one matched row at a time.

Each iteration of that walk calls `match_row()`, then `set_position()`, then `query_rows()` for a single row, then `seek_current()`. Four of those five resulting exmdb round trips are avoidable: `match_row()` issues `match_table`, `query_rows()` issues `query_table`, and `set_position()`, `query_rows()` and `seek_current()` each call `get_total()`, which for a content table issues `sum_table` and recounts the entire folder. A 31-day view that matches a thousand appointments therefore costs several thousand round trips, and the count grows with the number of items the view displays.

Applying the restriction with `mapi_table_restrict()` instead hands it to `exmdb_client->load_content_table()`, which filters while the table is being built, so the matching rows come back from a single `query_table`. `Operations::getTable()` already applies its restrictions this way, which is why the mail list view does not show the same cost.

## Measured

A calendar folder holding 20019 appointments (13956 single, 3009 all-day, 3035 recurring, of which 1012 have no end date), against a gromox backend. Each figure is the fastest of three `appointmentlistmodule` list requests over HTTP, so it includes the module, recurrence expansion and JSON encoding.

| view | before | after | speedup | items returned |
|---|---|---|---|---|
| 1 day | 3293.5 ms | 645.1 ms | 5.1x | 125 |
| 7 days | 3780.2 ms | 696.3 ms | 5.4x | 939 |
| 31 days | 5543.4 ms | 904.5 ms | 6.1x | 4156 |

The same three views on a 5019-appointment folder, fastest of four requests each:

| view | before | after | speedup | items returned |
|---|---|---|---|---|
| 1 day | 554.4 ms | 201.5 ms | 2.8x | 33 |
| 7 days | 662.3 ms | 220.5 ms | 3.0x | 252 |
| 31 days | 919.2 ms | 268.2 ms | 3.4x | 1079 |

Isolating the store half of the 7-day request on the larger folder, with the same restriction and the same 42 columns in both arms, gives 3416.5 ms for the current call and 174.4 ms for the restricted table, a 19.6x difference. What remains after this change is the table load itself, recurrence expansion in PHP and JSON encoding, which is why the end-to-end figures improve by 5x to 6x rather than 19x.

Two details of the shape are worth stating. The speedup grows with the size of the folder, because the number of round trips grows with the number of rows the view matches. And the one-day view on the larger folder returned 125 items and still cost 3.4 seconds before the change, because the table is walked across the whole folder however narrow the requested range is.

For comparison, loading that same 20019-appointment folder as a restricted table with a sort on the appointment start, which is the shape a MAPI client asks for, takes 179.7 ms. The store is not what makes the current path slow.

## What changed

`getCalendarItems()` now calls `mapi_table_restrict($table, $restriction, TBL_BATCH)` and queries the table without a restriction argument. The restriction itself is unchanged, and so is everything downstream of it: `processItems()` already sorts the result with `usort()`, so it does not depend on the order rows arrive in.

`BusyTimeListModule` extends `AppointmentListModule` and inherits `getCalendarItems()`, so the free/busy view takes the same path and the same change.

## Testing

The three views were each requested against both versions of the file in one run and the JSON responses compared byte for byte, at both folder sizes. On the 20019-appointment folder the responses were 180479, 1358886 and 5997415 bytes, and on the 5019-appointment folder 48122, 366575 and 1560933 bytes, identical on both sides in all six cases.

A shared calendar was then exercised in both permission states, since `getCalendarItems()` reads a foreign store when a delegate opens one and falls through to `getFreebusyItems()` when MAPI raises. A second mailbox holding 3012 appointments was opened by a delegate over the same HTTP entry point, once with the read right on the calendar and once with only the folder-visible right.

| shared calendar, 7-day view | before | after | result |
|---|---|---|---|
| delegate has read | 469.1 ms | 221.6 ms | 157 items both, responses identical at 218927 bytes |
| delegate has no read | 52.0 ms | 52.2 ms | same error both, `MAPI_E_NO_ACCESS`, 356 bytes |
