### PR TITLE
calendar: discard uncommitted quick-create text when the editor closes

### DIFF
--- a/client/zarafa/calendar/ui/TextEditView.js
+++ b/client/zarafa/calendar/ui/TextEditView.js
@@ -138,6 +138,12 @@ Zarafa.calendar.ui.TextEditView = Ext.extend(Zarafa.core.ui.View, {
 		this.makeElementsVisible([this.body, this.header], false);
 
 		this.visible = false;
+
+		// Discard text that was never committed with RETURN. Leaving it lets the
+		// next layout create an appointment out of it, long after the view closed.
+		this.body.dom.value = '';
+		this.header.dom.value = '';
+		this.inputText = '';
 	},
 
 	/**
@@ -263,13 +269,6 @@ Zarafa.calendar.ui.TextEditView = Ext.extend(Zarafa.core.ui.View, {
 			}
 		} else {
 			this.makeElementsVisible([this.body, this.header], false);
-
-			// If input text is not empty then create the appointment
-			if (!Ext.isEmpty(this.inputText)) {
-				var text = this.inputText;
-				this.inputText = '';
-				this.fireEvent('textentered', this, text);
-			}
 		}
 
 		Zarafa.calendar.ui.TextEditView.superclass.onLayout.call(this);


### PR DESCRIPTION
Creating appointments through the calendar occasionally leaves behind an extra appointment whose subject is a fragment of the one that was typed, most often a single character. It was reported against 3.19.171 after creating several appointments in a row through right-click, New Appointment, type a subject, Save.

## Where the text comes from

`Zarafa.calendar.ui.TextEditView` is the inline quick-create editor. `AbstractCalendarView#onKeyPress` opens it on any alphanumeric key while a range selection is active, and right-clicking a slot leaves that range selected. The New Appointment dialog is constructed asynchronously, so a keystroke typed before its subject field has focus goes to the calendar view, which opens this editor and focuses its textarea. `select()` selects the textarea content, so a following character replaces rather than appends, which is how a single middle character can end up stored.

`onKeyUp` copies the textarea into `this.inputText` on every key. When the dialog then takes focus the textarea blurs, `onBlur` calls `hide()`, and `hide()` leaves `inputText` set.

## Why it becomes an appointment

`onLayout` fires `textentered` whenever the view is not visible and `inputText` is non-empty, and `AbstractCalendarView#onTextEntered` turns that into `appointmentcreate`. `Zarafa.core.ui.View#layout` calls `onLayout` on every child view without checking visibility, so any later relayout of the calendar reaches it. Saving the appointment from the dialog adds it to the store, which relayouts the calendar, which replays the leftover keystroke as a second appointment.

That accounts for the shape of the report: the stray subject is a fragment because `inputText` holds only what was captured before focus moved, and it is rare because it needs a keystroke to land in the window between opening the menu item and the dialog taking focus.

The same leftover is reachable without a dialog at all: type into the quick-create editor, click elsewhere, and an appointment appears despite `onBlur` having fired `cancelled`. That `cancelled` event has no listener anywhere in the tree, so the commit-on-layout was the only behaviour it had.

## The change

`hide()` now clears both textareas and `inputText`, and the commit block is removed from `onLayout`. RETURN still creates the appointment, and it already captured the text and cleared `inputText` before calling `hide()`, so that path is unchanged.

This does change one behaviour: typing in the quick-create editor and then clicking away no longer creates the appointment. RETURN is now the only way it commits, which is what the `cancelled` event implies was intended.

## Testing

No browser was used. The five sequences below drive the real `TextEditView.js` under node, loaded through a stub `Ext.extend` so the shipped methods themselves run, with `keydown`, `keypress` and `keyup` delivered in browser order and `onKeyPress` bound to both `keydown` and `keypress` as `render()` does.

| sequence | before | after |
|---|---|---|
| select a range, type `test`, RETURN | 1 appointment, `test` | unchanged |
| type `te`, click away | 1 appointment, `te` | none |
| type `test`, RETURN, keep typing | 2 appointments, `test` and `t` | 1, `test` |
| two entries, second blurred after one character | 2 appointments, `test` and `e` | 1, `test` |
| right-click New Appointment, keystroke leaks before the dialog focuses | 1 appointment, `e` | none |

The fourth and fifth rows are the reported symptom.