### PR TITLE
calendar: opt-in setting for removing the request mail on response

### DIFF
--- a/client/zarafa/calendar/settings/SettingsCalendarWidget.js
+++ b/client/zarafa/calendar/settings/SettingsCalendarWidget.js
@@ -227,6 +227,16 @@ Zarafa.calendar.settings.SettingsCalendarWidget = Ext.extend(Zarafa.settings.ui.
 					check: this.onBoldCheck,
 					scope: this
 				}
+			},{
+				xtype: 'checkbox',
+				ref: 'removeRequestCheck',
+				boxLabel: _('Delete the meeting request from the inbox when answering from the calendar'),
+				hideLabel: true,
+				name: 'zarafa/v1/contexts/calendar/remove_meetingrequest_on_calendar_response',
+				listeners: {
+					check: this.onRemoveRequestCheck,
+					scope: this
+				}
 			}]
 		});
 
@@ -256,6 +266,7 @@ Zarafa.calendar.settings.SettingsCalendarWidget = Ext.extend(Zarafa.settings.ui.
 		this.zoomLevelCombo.setValue(settingsModel.get(this.zoomLevelCombo.name));
 		this.busyStatusCombo.setValue(settingsModel.get(this.busyStatusCombo.name));
 		this.boldCheck.setValue(settingsModel.get(this.boldCheck.name));
+		this.removeRequestCheck.setValue(settingsModel.get(this.removeRequestCheck.name));
 
 		this.durationSpinner.setValue(settingsModel.get(this.durationSpinner.name));
 
@@ -385,6 +396,20 @@ Zarafa.calendar.settings.SettingsCalendarWidget = Ext.extend(Zarafa.settings.ui.
 			if (this.model.get(field.name) !== check) {
 				this.model.set(field.name, check);
 			}
+		}
+	},
+
+	/**
+	 * Event handler which is fired when the "delete the meeting request" checkbox
+	 * has been clicked.
+	 * @param {Ext.form.Checkbox} field The checkbox which fired the event
+	 * @param {Boolean} check True if the checkbox is checked
+	 * @private
+	 */
+	onRemoveRequestCheck: function(field, check)
+	{
+		if (this.model && this.model.get(field.name) !== check) {
+			this.model.set(field.name, check);
 		}
 	},
 

--- a/client/zarafa/settings/data/SettingsDefaultValues.js
+++ b/client/zarafa/settings/data/SettingsDefaultValues.js
@@ -606,6 +606,14 @@ Zarafa.settings.data.SettingsDefaultValue = function(){
 								 */
 								'default_allday_busy_status': 0,
 								/**
+								 * zarafa/v1/contexts/calendar/remove_meetingrequest_on_calendar_response
+								 * Move the request mail out of the inbox when the meeting is
+								 * answered from the calendar. Off by default.
+								 * @property
+								 * @type Boolean
+								 */
+								'remove_meetingrequest_on_calendar_response': false,
+								/**
 								 * zarafa/v1/contexts/calendar/default_reminder
 								 * @property
 								 * @type Boolean

--- a/server/includes/modules/class.itemmodule.php
+++ b/server/includes/modules/class.itemmodule.php
@@ -12,6 +12,12 @@ class ItemModule extends Module {
 	public $directBookingMeetingRequest;
 
 	/**
+	 * The opt-in setting whether responding to a meeting outside the request mail
+	 * also removes that mail.
+	 */
+	public $removeRequestOnResponse;
+
+	/**
 	 * The array of properties which should not be copied during the copy() action.
 	 */
 	public $skipCopyProperties;
@@ -29,6 +35,10 @@ class ItemModule extends Module {
 	 */
 	public function __construct($id, $data) {
 		$this->directBookingMeetingRequest = ENABLE_DIRECT_BOOKING;
+		$this->removeRequestOnResponse = $GLOBALS['settings']->get(
+			'zarafa/v1/contexts/calendar/remove_meetingrequest_on_calendar_response',
+			false
+		);
 		$this->skipCopyProperties = [];
 		$this->plaintext = false;
 
@@ -111,7 +121,7 @@ class ItemModule extends Module {
 								// auto-processing in open().
 								mapi_deleteprops($message, [PR_PROCESSED]);
 
-								$req = new Meetingrequest($store, $message, $GLOBALS["mapisession"]->getSession(), $this->directBookingMeetingRequest);
+								$req = new Meetingrequest($store, $message, $GLOBALS["mapisession"]->getSession(), $this->directBookingMeetingRequest, $this->removeRequestOnResponse);
 
 								// Update extra body information
 								if (isset($action["message_action"]['meetingTimeInfo']) && !empty($action["message_action"]['meetingTimeInfo'])) {
@@ -262,7 +272,7 @@ class ItemModule extends Module {
 								$message = $GLOBALS["operations"]->openMessage($store, $entryid);
 								$basedate = (isset($action['basedate']) && !empty($action['basedate'])) ? $action['basedate'] : false;
 
-								$req = new Meetingrequest($store, $message, $GLOBALS["mapisession"]->getSession(), $this->directBookingMeetingRequest);
+								$req = new Meetingrequest($store, $message, $GLOBALS["mapisession"]->getSession(), $this->directBookingMeetingRequest, $this->removeRequestOnResponse);
 
 								// @FIXME: may be we can remove this body check any get it while declining meeting 'body'
 								$body = false;


### PR DESCRIPTION
Answering a meeting from the calendar rather than from the request mail leaves the request in the inbox, so the mail has to be deleted by hand. This adds a per-user setting that removes it, defaulting to off so nothing changes for anyone who does not turn it on.

Depends on the companion change in mapi-header-php, which gates the removal behind a constructor flag defaulting to `false`. Without that change this setting has no effect; with it and the setting off, behaviour is exactly as it is today.

## What changed

A new setting, `zarafa/v1/contexts/calendar/remove_meetingrequest_on_calendar_response`, defaulting to `false` in `SettingsDefaultValues.js`, and a checkbox for it in the Calendar settings widget alongside the existing date-picker one.

`ItemModule` reads it once in the constructor, next to `ENABLE_DIRECT_BOOKING`, and passes it as the fifth argument to `Meetingrequest` at the two places that respond on the user's behalf: the `acceptMeetingRequest` path, which calls `doAccept()` and `doDecline()`, and the `declineMeeting` path.

The third `Meetingrequest` in this module is deliberately left alone. It auto-processes a request when the mail is opened and calls `doAccept(true, false, false)`, leaving `$userAction` at its default of `false`, and the library gates the removal on `$userAction` being set, so auto-processing can never remove the mail.

## Why the setting is per user rather than a config constant

The objection to the original change was that clients should behave the same as one another. A per-user choice keeps that true: whoever does not opt in sees today's behaviour in every client, and whoever opts in has asked for the removal. A server-wide constant would instead let an administrator enable it for one client and not another.

## Testing

The gate itself was exercised at the library level against a gromox backend, by seeding a received meeting request, auto-processing it the way opening the mail does, and responding to the appointment in the calendar with the flag off and on:

| opt-in | Inbox | Deleted Items | request mail |
|---|---|---|---|
| off (default) | 55 to 55 | 10 to 10 | stays in the inbox |
| on | 55 to 54 | 10 to 11 | moved to Deleted Items |

Not covered: the checkbox itself. The setting was driven directly rather than through the Settings UI, so what is verified is that the value reaches `Meetingrequest` and changes the outcome, not that clicking the checkbox writes it.

ActiveSync is not part of this. grommunio-sync reads no grommunio-web settings today, so honouring the same per-user choice there is a separate change that should follow this one.