### PR TITLE
mail: move the new-mail folder scope into a reachable category

### DIFF
--- a/client/zarafa/common/settings/SettingsNotificationsCategory.js
+++ b/client/zarafa/common/settings/SettingsNotificationsCategory.js
@@ -34,9 +34,6 @@ Zarafa.common.settings.SettingsNotificationsCategory = Ext.extend(Zarafa.setting
 			items: [{
 					xtype: 'zarafa.settingsdesktopnotificationswidget',
 					settingsContext: config.settingsContext
-				}, {
-					xtype: 'zarafa.settingsnewmailfolderswidget',
-					settingsContext: config.settingsContext
 				},
 				container.populateInsertionPoint('context.settings.category.notifications', this)
 			]

--- a/client/zarafa/mail/settings/SettingsMailCategory.js
+++ b/client/zarafa/mail/settings/SettingsMailCategory.js
@@ -62,6 +62,8 @@ Zarafa.mail.settings.SettingsMailCategory = Ext.extend(Zarafa.settings.ui.Settin
 			container.populateInsertionPoint('context.settings.category.mail.aftercomposesettings', this),
 			{
 				xtype: 'zarafa.settingsincomingmailwidget'
+			},{
+				xtype: 'zarafa.settingsnewmailfolderswidget'
 			}
 		];
 


### PR DESCRIPTION
he new-mail folder scope added in b4895dc1e cannot be reached from the interface. It was placed in `SettingsNotificationsCategory`, and that category is never registered.

## Why it is not reachable

`CommonContext` registers the delegate, send-as and rule categories, and the line for the notifications category is commented out:

```js
this.registerInsertionPoint('context.settings.categories', this.createRuleSettingsCategory, this);
//this.registerInsertionPoint('context.settings.categories', this.createNotificationSettingsCategory, this);
```

That comment predates the widget: it has been in place since `7fe0804e5 upgrade: upgrade to 2.5`. So `zarafa.settingsnotificationscategory` produces no tab, and the two widgets inside it are unreachable, including the new one.

The Settings list a user sees therefore has no Notifications entry. The `Desktop Notifications` entry that is present comes from the `desktopnotifications` plugin, which registers its own category through `context.settings.categories` and contains only its own widget.