### PR TITLE
oof: show the subject the server sends when none is set

### DIFF
--- a/client/zarafa/common/outofoffice/data/OofRecord.js
+++ b/client/zarafa/common/outofoffice/data/OofRecord.js
@@ -24,7 +24,10 @@ Zarafa.common.outofoffice.data.OofRecordFields = [
   {name: 'allow_external'},
   {name: 'external_audience'},
   {name: 'external_reply'},
-  {name: 'external_subject'}
+  {name: 'external_subject'},
+  // Read only, filled in from the server's configuration.
+  {name: 'subject_prefix_set', type: 'boolean'},
+  {name: 'subject_prefix'}
 ];
 
 /**

--- a/client/zarafa/mail/settings/SettingsOofWidget.js
+++ b/client/zarafa/mail/settings/SettingsOofWidget.js
@@ -545,10 +545,18 @@ Zarafa.mail.settings.SettingsOofWidget = Ext.extend(Zarafa.settings.ui.SettingsW
 			this.backDateTimeField.setValue(this.backDateTimeField.defaultValue);
 		}
 
-		var intSubject = record.get(this.intSubjectField.name) || this.intSubjectField.defaultValue;
+		// An empty field is what asks the server for its own subject, so it must
+		// not be prefilled with a default of ours.
+		var prefix = this.getServerSubjectPrefix();
+		this.applySubjectPrefix(this.intSubjectField, prefix);
+		this.applySubjectPrefix(this.extSubjectField, prefix);
+
+		var intSubject = record.get(this.intSubjectField.name) ||
+			(prefix === null ? this.intSubjectField.defaultValue : '');
 		this.intSubjectField.setValue(intSubject);
 
-		var extSubject = record.get(this.extSubjectField.name) || this.extSubjectField.defaultValue;
+		var extSubject = record.get(this.extSubjectField.name) ||
+			(prefix === null ? this.extSubjectField.defaultValue : '');
 		this.extSubjectField.setValue(extSubject);
 
 		var intBody = record.get(this.intBodyField.name) || this.intBodyField.defaultValue;
@@ -560,6 +568,48 @@ Zarafa.mail.settings.SettingsOofWidget = Ext.extend(Zarafa.settings.ui.SettingsW
 		}
 
 		this.loading = false;
+	},
+
+	/**
+	 * @return {String} the server side prefix, null when it applies none. An
+	 * empty string means it was told to send no subject at all.
+	 * @private
+	 */
+	getServerSubjectPrefix: function()
+	{
+		if (!this.record || this.record.get('subject_prefix_set') !== true) {
+			return null;
+		}
+
+		return this.record.get('subject_prefix') || '';
+	},
+
+	/**
+	 * @param {Ext.form.TextField} field subject field to describe
+	 * @param {String} prefix server side prefix, null when it has none
+	 * @private
+	 */
+	applySubjectPrefix: function(field, prefix)
+	{
+		var previous = field.emptyText;
+
+		if (prefix === null) {
+			field.emptyText = field.defaultValue;
+		} else if (prefix === '') {
+			field.emptyText = _('No subject');
+		} else {
+			// Assembled as the server will, separator included.
+			field.emptyText = prefix + _('Subject of the message replied to');
+		}
+
+		// applyEmptyText skips a field that is not empty, and one still showing
+		// the previous placeholder does not look empty to it.
+		if (field.rendered && field.emptyText !== previous) {
+			if (field.el.dom.value === previous) {
+				field.setRawValue('');
+			}
+			field.applyEmptyText();
+		}
 	},
 
 	/**
@@ -594,8 +644,15 @@ Zarafa.mail.settings.SettingsOofWidget = Ext.extend(Zarafa.settings.ui.SettingsW
 	{
 		// We must either set the requested subject, or the default subject.
 		// A subject of nothing but spaces is as empty as no subject at all.
-		var intsubject = this.intSubjectField.getValue().trim() || this.intSubjectField.emptyText;
-		var extsubject = this.extSubjectField.getValue().trim() || this.extSubjectField.emptyText;
+		// Except with a server prefix, where storing nothing is what asks for
+		// it and the placeholder is not a storable subject.
+		var prefix = this.getServerSubjectPrefix();
+		var intsubject = this.intSubjectField.getValue().trim();
+		var extsubject = this.extSubjectField.getValue().trim();
+		if (prefix === null) {
+			intsubject = intsubject || this.intSubjectField.emptyText;
+			extsubject = extsubject || this.extSubjectField.emptyText;
+		}
 
 		// We must either set the requested body, or the default body
 		var intbody = this.intBodyField.getValue() || this.intBodyField.emptyText;

--- a/config.php.dist
+++ b/config.php.dist
@@ -169,6 +169,14 @@
 	// read, in seconds.
 	define('ADMIN_API_DISABLEDPLUGINS_RETRY_TIME', 30);
 
+	// The grommunio admin API endpoint reporting the out of office subject
+	// prefix gromox applies when a mailbox has none of its own.
+	define('ADMIN_API_OOFSUBJECTPREFIX_ENDPOINT', ADMIN_API_ENDPOINT . 'oofSubjectPrefix');
+
+	// How long to wait for it, in seconds. The out of office form waits on
+	// this, so keep it short.
+	define('ADMIN_API_OOFSUBJECTPREFIX_TIMEOUT', 3);
+
 	// Whether to show the Logout button in grommunio-web (true or false).
 	// Show per default.
 	define('SHOW_LOGOUT_BUTTON', true);

--- a/defaults.php
+++ b/defaults.php
@@ -787,3 +787,13 @@ if (!defined('ADMIN_API_DISABLEDPLUGINS_CACHE_TIME')) {
 if (!defined('ADMIN_API_DISABLEDPLUGINS_RETRY_TIME')) {
 	define('ADMIN_API_DISABLEDPLUGINS_RETRY_TIME', 30);
 }
+
+// The grommunio admin API out of office subject prefix endpoint
+if (!defined('ADMIN_API_OOFSUBJECTPREFIX_ENDPOINT')) {
+	define('ADMIN_API_OOFSUBJECTPREFIX_ENDPOINT', ADMIN_API_ENDPOINT . 'oofSubjectPrefix');
+}
+
+// Seconds to wait for the out of office subject prefix answer
+if (!defined('ADMIN_API_OOFSUBJECTPREFIX_TIMEOUT')) {
+	define('ADMIN_API_OOFSUBJECTPREFIX_TIMEOUT', 3);
+}

--- a/server/includes/modules/class.outofofficesettingsmodule.php
+++ b/server/includes/modules/class.outofofficesettingsmodule.php
@@ -5,6 +5,14 @@
  */
 class OutOfOfficeSettingsModule extends Module {
 	/**
+	 * Server side subject prefix, null when it applies none, false until
+	 * looked up.
+	 *
+	 * @var null|bool|string
+	 */
+	private $subjectPrefix = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int   $id   unique id
@@ -14,6 +22,19 @@ class OutOfOfficeSettingsModule extends Module {
 		parent::__construct($id, $data);
 
 		$this->properties = $GLOBALS["properties"]->getOutOfOfficeProperties();
+	}
+
+	/**
+	 * Asked for at most once per request.
+	 *
+	 * @return null|string the prefix, or null when the server applies none
+	 */
+	private function getSubjectPrefix() {
+		if ($this->subjectPrefix === false) {
+			$this->subjectPrefix = queryAdminApiOofSubjectPrefix();
+		}
+
+		return $this->subjectPrefix;
 	}
 
 	/**
@@ -45,6 +66,9 @@ class OutOfOfficeSettingsModule extends Module {
 	public function getOofSettings() {
 		$otherStores = $this->getOwnerPermissionStores();
 		array_unshift($otherStores, $GLOBALS['mapisession']->getDefaultMessageStore());
+
+		// Server wide, so the same for every store below.
+		$subjectPrefix = $this->getSubjectPrefix();
 
 		$oofSettings = [];
 		foreach ($otherStores as $storeEntryId => $storeObj) {
@@ -88,6 +112,8 @@ class OutOfOfficeSettingsModule extends Module {
 			$externalProps['props']['external_audience'] = $props[PR_EC_EXTERNAL_AUDIENCE];
 			$externalProps['props']['external_reply'] = trim((string) $props[PR_EC_EXTERNAL_REPLY]);
 			$externalProps['props']['external_subject'] = trim((string) $props[PR_EC_EXTERNAL_SUBJECT]);
+			$externalProps['props']['subject_prefix_set'] = $subjectPrefix !== null;
+			$externalProps['props']['subject_prefix'] = $subjectPrefix ?? '';
 
 			array_push($oofSettings, $externalProps);
 		}
@@ -174,16 +200,20 @@ class OutOfOfficeSettingsModule extends Module {
 		// their mailbox, so make sure a subject is stored whenever out of office
 		// is on. The client offers the same default in the settings form, but it
 		// is not the only way these properties are written.
-		foreach (['internal_subject', 'external_subject'] as $subject) {
-			$tag = $this->properties[$subject];
+		// Unless the server has a prefix, where an empty property is what
+		// activates it and what it sends beats this default.
+		if ($this->getSubjectPrefix() === null) {
+			foreach (['internal_subject', 'external_subject'] as $subject) {
+				$tag = $this->properties[$subject];
 
-			if (array_key_exists($tag, $props)) {
-				if (trim((string) $props[$tag]) === '') {
+				if (array_key_exists($tag, $props)) {
+					if (trim((string) $props[$tag]) === '') {
+						$props[$tag] = Language::getstring('Out of Office');
+					}
+				}
+				elseif ($oofSet && trim((string) ($oofProps[$tag] ?? '')) === '') {
 					$props[$tag] = Language::getstring('Out of Office');
 				}
-			}
-			elseif ($oofSet && trim((string) ($oofProps[$tag] ?? '')) === '') {
-				$props[$tag] = Language::getstring('Out of Office');
 			}
 		}
 

--- a/server/includes/util.php
+++ b/server/includes/util.php
@@ -828,6 +828,28 @@ function queryAdminApiDisabledPlugins() {
 }
 
 /**
+ * Asks the admin API for the subject prefix the server applies when a mailbox
+ * has no out of office subject of its own. An unset directive counts as no
+ * prefix, because the default that then applies is compiled into the server.
+ *
+ * @return null|string the prefix, or null when none applies or it could not
+ *                     be asked
+ */
+function queryAdminApiOofSubjectPrefix() {
+	$context = stream_context_create([
+		'http' => ['timeout' => ADMIN_API_OOFSUBJECTPREFIX_TIMEOUT],
+	]);
+	$res = @json_decode(@file_get_contents(
+		ADMIN_API_OOFSUBJECTPREFIX_ENDPOINT, false, $context), true);
+
+	if (empty($res['data']['configured']) || !is_string($res['data']['prefix'] ?? null)) {
+		return null;
+	}
+
+	return $res['data']['prefix'];
+}
+
+/**
  * Helper function which provide protocol used by current request.
  *
  * @return string it can be either https or http


### PR DESCRIPTION
An out-of-office reply carries the subject stored alongside the message. Clients configuring out of office over EWS cannot store one, so gromox falls back to gromox.cfg:autoreply_subject_prefix plus the subject of the message being replied to.

This application never reaches that fallback. It writes "Out of Office" into the property whenever the field is left empty, so the property is never empty and the server never gets to fill it in. The result is a fixed subject where an Outlook user on the same server gets the prefix followed by the original subject, which is the better of the two and the one the rest of the organisation sees.

Ask the admin API for the prefix, show it in the form as the placeholder for both subject fields, and leave the property empty so the server can apply it.

Only when the admin API reports a configured prefix. An unset directive, an admin API that cannot be reached and an older server that has no such directive all leave the previous behaviour untouched, so no deployment loses the subject it has today.