### PR TITLE
freebusy: working elsewhere should not block a meeting

### DIFF
--- a/client/zarafa/common/freebusy/data/FreebusyModel.js
+++ b/client/zarafa/common/freebusy/data/FreebusyModel.js
@@ -1007,43 +1007,43 @@ Zarafa.common.freebusy.data.FreebusyModel = Ext.extend(Ext.util.Observable,
 		// Always start with a clean store
 		this.suggestionBlockStore.removeAll();
 
-		if (this.freeBlockStore.getCount() > 0) {
-			var start = this.suggestionRange.getStartTime() / 1000;
-			var end = this.suggestionRange.getDueTime() / 1000;
-			var duration = this.selectorRange.getDuration(Date.SECOND);
-			var interval = Ext.min([duration, 30 * 60]); // FIXME: make configurable
+		var start = this.suggestionRange.getStartTime() / 1000;
+		var end = this.suggestionRange.getDueTime() / 1000;
+		var duration = this.selectorRange.getDuration(Date.SECOND);
+		var interval = Ext.min([duration, 30 * 60]); // FIXME: make configurable
 
-			// But what if the appointment takes 0 minutes..
-			// That would be dumb, but we won't be fooled!
-			if (interval <= 0) {
-				interval = 30 * 60;
+		// But what if the appointment takes 0 minutes..
+		// That would be dumb, but we won't be fooled!
+		if (interval <= 0) {
+			interval = 30 * 60;
+		}
+
+		// An empty store means nobody is occupied, which is the case where every
+		// slot is a suggestion. The leftover below covers the whole range.
+		this.freeBlockStore.each(function(sumBlock) {
+			var sumStart = sumBlock.get('start');
+			var sumEnd = sumBlock.get('end');
+
+			if (sumEnd < start || sumStart > end) {
+				// The block falls entirely before or entirely after the
+				// requested range, so it contributes nothing. Any range left
+				// over after the loop is added below.
+				return;
+			} else if (sumStart <= start) {
+				// The block overlap our range, our new start
+				// time is the end time of this block.
+				start = sumEnd;
+			} else {
+				// The entire block falls after our start range,
+				// simply add a suggestionblock from start to the sumBlock start.
+				this.suggestionBlockStore.add(this.createSuggestionBlocks(start, Ext.min([sumStart, end]), duration, interval));
+				start = sumEnd;
 			}
+		}, this);
 
-			this.freeBlockStore.each(function(sumBlock) {
-				var sumStart = sumBlock.get('start');
-				var sumEnd = sumBlock.get('end');
-
-				if (sumEnd < start || sumStart > end) {
-					// The block falls entirely before or entirely after the
-					// requested range, so it contributes nothing. Any range left
-					// over after the loop is added below.
-					return;
-				} else if (sumStart <= start) {
-					// The block overlap our range, our new start
-					// time is the end time of this block.
-					start = sumEnd;
-				} else {
-					// The entire block falls after our start range,
-					// simply add a suggestionblock from start to the sumBlock start.
-					this.suggestionBlockStore.add(this.createSuggestionBlocks(start, Ext.min([sumStart, end]), duration, interval));
-					start = sumEnd;
-				}
-			}, this);
-
-			// Check if we still have a leftover...
-			if (start < end) {
-				this.suggestionBlockStore.add(this.createSuggestionBlocks(start, end, duration, interval));
-			}
+		// Check if we still have a leftover...
+		if (start < end) {
+			this.suggestionBlockStore.add(this.createSuggestionBlocks(start, end, duration, interval));
 		}
 
 		this.suggestionBlockStore.fireEvent('load', this.suggestionBlockStore, this.suggestionBlockStore.getRange(), {});

--- a/client/zarafa/common/freebusy/data/FreebusyModel.js
+++ b/client/zarafa/common/freebusy/data/FreebusyModel.js
@@ -938,10 +938,30 @@ Zarafa.common.freebusy.data.FreebusyModel = Ext.extend(Ext.util.Observable,
 			// FIXME: We should actually build this store while building
 			// the busy blocks. This is most likely faster then doing it
 			// separately.
-			this.mergeBlocksToSumBlockStore(records, this.freeBlockStore, false);
+			// The blocks are filtered here rather than in the sum blocks, so a
+			// status that does not occupy the attendee stays on the timeline.
+			this.mergeBlocksToSumBlockStore(records.filter(function(record) {
+				return this.occupiesAttendee(record.get('status'));
+			}, this), this.freeBlockStore, false);
 		}
 
 		this.loadSuggestionBlocks();
+	},
+
+	/**
+	 * Whether a busy status makes an attendee unavailable for a new meeting.
+	 * Working Elsewhere does not. The attendee is working, only not at their
+	 * usual location, which is the status Outlook assigns to a home office day.
+	 * @param {Zarafa.core.mapi.BusyStatus} status The busy status to check
+	 * @return {Boolean} True if the attendee cannot take a meeting
+	 */
+	occupiesAttendee: function(status)
+	{
+		var BusyStatus = Zarafa.core.mapi.BusyStatus;
+
+		return status !== BusyStatus.FREE &&
+			status !== BusyStatus.UNKNOWN &&
+			status !== BusyStatus.WORKINGELSEWHERE;
 	},
 
 	/**
@@ -1118,7 +1138,7 @@ Zarafa.common.freebusy.data.FreebusyModel = Ext.extend(Ext.util.Observable,
 			// remove appointments occurring extremely before our selected time
 			if (record.get('end') > periodStartTime) {
 				// check if we are really interested in this block
-				if (record.get('status') === Zarafa.core.mapi.BusyStatus.FREE || record.get('status') === Zarafa.core.mapi.BusyStatus.UNKNOWN) {
+				if (!this.occupiesAttendee(record.get('status'))) {
 					continue;
 				}
 

--- a/server/includes/modules/class.freebusymodule.php
+++ b/server/includes/modules/class.freebusymodule.php
@@ -77,10 +77,12 @@ class FreeBusyModule extends Module {
 		}
 		catch (Exception $e) {
 			error_log(sprintf("getFreeBusyInfo exception: %s (0x%08X)", $e->getMessage(), $e->getCode()));
+			// -1 is the client's status for an absent answer. fbNoData cannot
+			// say it here, because it shares its value with fbWorkingElsewhere.
 			$result[] = [
 				'start' => $start,
 				'end' => $end,
-				'status' => fbNoData,
+				'status' => -1,
 			];
 		}
 


### PR DESCRIPTION
An attendee who marks a day as Working Elsewhere gets no suggested times at all for that day. The status is the one Outlook assigns to a home office day, so this affects everyone who records one.

Three separate causes, one per commit. The first two both have to be fixed for the symptom to go away, which is why they are in one PR.

## 1. No suggestions at all when nobody is occupied

`loadSuggestionBlocks` ran its whole body only when the store of occupied periods held at least one block. A day on which no attendee is occupied therefore produced nothing to pick, and so did a calendar holding only blocks marked free.

The loop over the occupied periods already handles the empty case by not iterating, and the leftover branch after it already covers whatever range no block consumed, so dropping the guard is the entire fix. `git diff -w` for that commit is **2 insertions, 2 deletions**; the 35 lines it reports otherwise are the re-indent.

This matters for the report because Working Elsewhere is usually the *only* thing in the calendar on a home office day. Stopping it from occupying the attendee empties the store, and without this commit an empty store still means no suggestions.

## 2. Working Elsewhere occupied the attendee

`WORKINGELSEWHERE` appeared nowhere in the availability logic. Both places that judge availability asked whether the status was *not* Free and *not* Unknown, which put Working Elsewhere in the same bucket as Busy. A day-long marker consumed the entire window; a shorter one moved the first suggestion past its end.

Both places now ask a single `occupiesAttendee`. Free, Unknown and Working Elsewhere do not occupy an attendee; Busy, Tentative and Out Of Office still do.

The blocks are filtered where the occupied periods are derived, not where the sum blocks are built, so **the Working Elsewhere marker stays on the timeline** and only stops counting as a conflict. The same helper is used by the warning shown when a slot is picked by hand, so the two features no longer disagree about the same slot.

## 3. A failed freebusy read looked like Working Elsewhere

`fbNoData` and `fbWorkingElsewhere` are both **4**. `FreeBusyModule::getFreeBusyInfo` sent `fbNoData` when the read threw, and once the client gave 4 its Outlook meaning, a failed read started drawing a Working Elsewhere marker across the whole requested range.

It now sends `-1`, which is the status the client already uses for an answer it does not have. The client renders that as no information and already draws no marker for it, so nothing else had to change.

# Verified

`FreebusyModel.js` is exercised by loading the shipped file and driving the real chain — `blockStore` → `onBlockLoad` → `sumBlockStore` → `onSumBlockLoad` → `freeBlockStore` → `loadSuggestionBlocks` — for a 30-minute meeting in an 08:00–18:00 window. 27 assertions, all passing. Both paths into the obstacle store are covered, the single-attendee one and the multi-attendee one through `mergeBlocksToSumBlockStore`.

| calendar contains | before | after |
|---|---|---|
| Working Elsewhere all day | **no suggestions** | 20 slots from 08:00 |
| Working Elsewhere 08:00–12:00 | 12 slots, first at 12:00 | 20 slots from 08:00 |
| nothing at all | **no suggestions** | 20 slots from 08:00 |
| one block marked free, all day | **no suggestions** | 20 slots from 08:00 |
| Busy all day | no suggestions | no suggestions |
| Busy 08:00–12:00 | 12 slots, first at 12:00 | 12 slots, first at 12:00 |
| Out Of Office all day | no suggestions | no suggestions |
| Tentative all day | no suggestions | no suggestions |
| Working Elsewhere all day **plus** Busy 08:00–12:00 | no suggestions | 12 slots, first at 12:00 |

The last four rows are the point of the table: everything that blocked still blocks, and a real conflict inside a Working Elsewhere day is still respected.