### PR TITLE
datepicker: changing the shown month is not a selection

### DIFF
--- a/client/extjs-mod/Ext.DatePicker.js
+++ b/client/extjs-mod/Ext.DatePicker.js
@@ -179,6 +179,54 @@
 			}
 
 			orig_selectToday.apply(this, arguments);
+		},
+
+		/**
+		 * Marks the cell holding {@link #value}, and no other, as the selected one.
+		 * {@link #update} marks the date it is handed, which for a change of month
+		 * is the same day in the new month rather than the selected date.
+		 * @private
+		 */
+		markSelectedDate: function()
+		{
+			if(!this.rendered || !this.cells) {
+				return;
+			}
+
+			this.cells.removeClass('x-date-selected');
+
+			if(!Ext.isDate(this.value)) {
+				return;
+			}
+
+			var selected = this.value.clearTime(true).getTime();
+
+			this.cells.each(function(cell) {
+				if(cell.dom.firstChild.dateValue === selected) {
+					cell.addClass('x-date-selected');
+
+					return false;
+				}
+			});
 		}
+	});
+
+	// Every one of these ends in update() with a date in another month, carrying
+	// the day across. Cursor movement inside a month is left alone, so the arrow
+	// keys keep marking where they are.
+	Ext.each([
+		'showPrevMonth',
+		'showNextMonth',
+		'showPrevYear',
+		'showNextYear',
+		'onMonthClick',
+		'onMonthDblClick'
+	], function(name) {
+		var orig = Ext.DatePicker.prototype[name];
+
+		Ext.DatePicker.prototype[name] = function() {
+			orig.apply(this, arguments);
+			this.markSelectedDate();
+		};
 	});
 })();

--- a/client/zarafa/common/freebusy/ui/SuggestionListPanel.js
+++ b/client/zarafa/common/freebusy/ui/SuggestionListPanel.js
@@ -140,7 +140,7 @@ Zarafa.common.freebusy.ui.SuggestionListPanel = Ext.extend(Ext.Panel, {
 	onDateRangeUpdate: function(newRange, oldRange)
 	{
 		this.suggestionDate.setMinDate(newRange.getStartDate());
-		this.suggestionDate.setmaxDate(newRange.getDueDate());
+		this.suggestionDate.setMaxDate(newRange.getDueDate());
 	},
 
 	/**


### PR DESCRIPTION
With 10 September selected in the suggested-times picker, clicking the next-month arrow marks **10 October** as selected. Nothing was selected, the value is unchanged, and the timeline beside the picker still shows 10 September, so the calendar and the panel next to it disagree about what is selected.

## Why

`update()` marks the date it is handed:

```js
sel = date.clearTime(true).getTime(),
...
if(t == sel){
    cell.className += ' x-date-selected';
```

and every way of changing the shown month hands it the same day in the month being moved to. `showNextMonth` and `showPrevMonth` use `this.activeDate.add('mo', ±1)`, the year pair does the same with `'y'`, and the month picker is explicit about it:

```js
var d = new Date(this.mpSelYear, this.mpSelMonth, (this.activeDate || this.value).getDate());
```

`this.value` is never consulted, so the mark follows what is on screen rather than what is selected.

## What changed

`markSelectedDate` marks the cell holding `value`, and none when the month on screen does not hold it. The six methods that change the shown month are wrapped to call it after Ext is done.

**Wrapping those six rather than `update()` itself is the point.** `x-date-selected` does double duty in this class: it marks the selection and it marks where the arrow keys are. Arrow keys reach `update()` directly, so they keep marking their position; only a change of month is treated as not being a selection.

This is in `client/extjs-mod/`, so it applies to every date picker in the client rather than to the freebusy panel alone. The behaviour it removes is wrong everywhere, including the `DateField` dropdowns.

## Second commit, unrelated to the above

`SuggestionListPanel.onDateRangeUpdate` called `setmaxDate`, which does not exist; the method is `setMaxDate`. The handler is wired to every update of the freebusy date range, so it threw each time, and since `setMinDate` on the line before had already run the picker was left holding a new lower bound and a stale upper one. One character.

## Verified

The real `Ext.DatePicker` class body and the real override file are loaded and driven; `update()` is the shipped function rather than a stand-in. `internalRender` is preset so `update()` skips its element-width branch, which is the only part that needs a browser; everything it does to the cells runs untouched.

| action, with 10 September selected | before | after |
|---|---|---|
| open the picker | 10 September marked | 10 September marked |
| next month | **10 October marked** | nothing marked |
| back to September | 10 September marked | 10 September marked |
| previous month again | **10 August marked** | nothing marked |
| next year | **10 September 2027 marked** | nothing marked |
| month picker, pick December | **10 December marked** | nothing marked |
| arrow key inside September | 11 September marked | 11 September marked |
| `value` after two navigations | 10 September | 10 September |
