### PR TITLE
core: let the interface finish a context switch

### DIFF
--- a/client/zarafa/core/Container.js
+++ b/client/zarafa/core/Container.js
@@ -640,13 +640,20 @@ Zarafa.core.Container = Ext.extend(Ext.util.Observable, {
 			this.currentContext = context;
 
 			this.fireEvent('folderselect', folder);
-			this.fireEvent('contextswitch', folder, oldContext, context);
 
 			// Nothing needs to be done between 'contextswitch' and 'aftercontextswitch',
 			// the difference between the two events is that the first one can be used
 			// internally for building up the UI, while the latter event is ideal for
 			// plugins which want the UI components to be setup correctly.
-			this.fireEvent('aftercontextswitch', folder, oldContext, context);
+			//
+			// A handler that throws leaves the ones behind it unreached, so the
+			// second event fires either way and lets the interface catch up. The
+			// error still surfaces once it has.
+			try {
+				this.fireEvent('contextswitch', folder, oldContext, context);
+			} finally {
+				this.fireEvent('aftercontextswitch', folder, oldContext, context);
+			}
 		}
 	},
 

--- a/client/zarafa/core/ui/NavigationPanel.js
+++ b/client/zarafa/core/ui/NavigationPanel.js
@@ -199,6 +199,25 @@ Zarafa.core.ui.NavigationPanel = Ext.extend(Zarafa.core.ui.MainViewSidebar, {
 	},
 
 	/**
+	 * Brings the panel to the active Context when the 'contextswitch' handler did
+	 * not reach it, which is what happens when a handler ahead of it threw. Does
+	 * nothing when the panel already followed.
+	 * @param {Object} parameters contains folder details
+	 * @param {Context} oldContext previously selected context
+	 * @param {Context} newContext selected context
+	 *
+	 * @private
+	 */
+	onAfterContextSwitch: function(parameters, oldContext, newContext)
+	{
+		if (!newContext || this.activeContext === newContext) {
+			return;
+		}
+
+		this.onContextSwitch(parameters, oldContext, newContext);
+	},
+
+	/**
 	 * Set all components that are related to the active Context to visible and hide the other
 	 * ones. The {@link #centerPanel centerPanel} is always visible and contains a card layout. It
 	 * will switch to the tab that is related to the active Context as well. If no tab is related
@@ -323,6 +342,7 @@ Zarafa.core.ui.NavigationPanel = Ext.extend(Zarafa.core.ui.MainViewSidebar, {
 	{
 		this.activeContext = container.getCurrentContext();
 		this.mon(container, 'contextswitch', this.onContextSwitch, this);
+		this.mon(container, 'aftercontextswitch', this.onAfterContextSwitch, this);
 		this.onContextSwitch(null, this.activeContext, this.activeContext);
 
 		this.on('resize', this.onResizePanel, this);


### PR DESCRIPTION
Switching between Mail and Calendar sometimes leaves the navigation pane on the mail folders. The main view switches correctly; only the pane is wrong. It happens occasionally, not on every switch.

## What the symptom rules out

`NavigationPanel` and the main view are both driven by `contextswitch`. Since the main view switched, the event fired and reached `ContextContainer`.

Index 0 of the pane's card layout is the "Folders List" panel, which `getAllFoldersPanel` unshifts to the front. So had the panel-matching loop simply failed to match, the fallback would have shown that folder list. It showed the mail folders instead, which means `setActiveItem` was not reached at all, and the pane still held the card from before the switch.

That leaves a handler for `contextswitch` throwing between the one that updates the main view and the one that updates the pane. Ext stops dispatching an event when a handler throws, so everything registered behind it is skipped, and the interface is left halfway through the switch.

## The change

`switchContext` fires `aftercontextswitch` even when `contextswitch` did not get through, and the navigation pane uses that second event to catch up if it was not reached. It does nothing there when it already followed, so the ordinary path is untouched.

**The error is not swallowed.** It propagates once the second event has been fired, so a broken listener still reaches the console. That matters here: the underlying handler is still unidentified, and this change makes it visible rather than hiding it.

## Verified

`switchContext` and `NavigationPanel.onAfterContextSwitch` are both extracted from the files and run for real, the first checked to contain the `try`/`finally` before the harness will proceed. 10 assertions.

| situation | before | after |
|---|---|---|
| healthy switch, both events | both fire | both fire |
| a `contextswitch` handler throws | **`aftercontextswitch` never fires** | it fires |
| a handler throws, error handling | propagates | propagates |
| pane already followed | — | catch-up does nothing |
| pane left behind | — | catch-up lands it on the new context |
| `newContext` missing | — | returns rather than throwing |
| handler throws, end to end | main view switched, **pane stranded** | main view switched, pane followed |

The "before" column is a run against `master`'s own files, md5-checked as `master`'s, not a description. The main suite refuses to run against `master` at all, because the `try`/`finally` it asserts on is absent there.