### PR TITLE
sendas: a send to one's own identity is not a delegate send

### DIFF
--- a/server/includes/core/class.operations.php
+++ b/server/includes/core/class.operations.php
@@ -2655,6 +2655,35 @@ class Operations {
 	}
 
 	/**
+	 * Whether an address denotes the logged-in user themselves. Their identity
+	 * reaches us in more than one spelling, the logon name among them, so each
+	 * is compared rather than the SMTP address alone.
+	 *
+	 * @param mixed $address address to test
+	 *
+	 * @return bool true when the address is one of the logged-in user's own
+	 */
+	private function isOwnIdentity($address) {
+		if (empty($address)) {
+			return false;
+		}
+
+		$own = [
+			$GLOBALS['mapisession']->getSMTPAddress(),
+			$GLOBALS['mapisession']->getEmailAddress(),
+			$GLOBALS['mapisession']->getUserName(),
+		];
+
+		foreach ($own as $mine) {
+			if (!empty($mine) && strcasecmp((string) $address, (string) $mine) == 0) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Submit a message for sending.
 	 *
 	 * This function is an extension of the saveMessage() function, with the extra functionality
@@ -3050,8 +3079,12 @@ class Operations {
 			$reprEmail = $props[PR_SENT_REPRESENTING_EMAIL_ADDRESS] ?? $reprProps[PR_SENT_REPRESENTING_EMAIL_ADDRESS] ?? null;
 			$reprEntryid = $props[PR_SENT_REPRESENTING_ENTRYID] ?? $reprProps[PR_SENT_REPRESENTING_ENTRYID] ?? null;
 			$reprSender = $props[PR_SENDER_EMAIL_ADDRESS] ?? $reprProps[PR_SENDER_EMAIL_ADDRESS] ?? null;
+			// The two addresses can spell the same person differently, so a send is
+			// only on behalf of somebody else when the representing identity is
+			// not the sender's own.
 			if ($reprEmail !== null && $reprEntryid !== null && $reprSender !== null &&
-				strcasecmp((string) $reprEmail, (string) $reprSender) != 0) {
+				strcasecmp((string) $reprEmail, (string) $reprSender) != 0 &&
+				!$this->isOwnIdentity($reprEmail)) {
 				$ab = $GLOBALS['mapisession']->getAddressbook();
 				$abitem = mapi_ab_openentry($ab, $reprEntryid);
 				$abitemprops = mapi_getprops($abitem, [PR_DISPLAY_NAME, PR_EMAIL_ADDRESS, PR_SEARCH_KEY]);
@@ -3071,7 +3104,8 @@ class Operations {
 			}
 			if (!$sendingAsDelegate &&
 				isset($props[PR_SENT_REPRESENTING_EMAIL_ADDRESS], $props[PR_SENDER_EMAIL_ADDRESS], $props[PR_SENT_REPRESENTING_ENTRYID]) &&
-				strcasecmp((string) $props[PR_SENT_REPRESENTING_EMAIL_ADDRESS], (string) $props[PR_SENDER_EMAIL_ADDRESS]) != 0) {
+				strcasecmp((string) $props[PR_SENT_REPRESENTING_EMAIL_ADDRESS], (string) $props[PR_SENDER_EMAIL_ADDRESS]) != 0 &&
+				!$this->isOwnIdentity($props[PR_SENT_REPRESENTING_EMAIL_ADDRESS])) {
 				// preserve sending from an alias
 				$ab = $GLOBALS['mapisession']->getAddressbook();
 				$abitem = mapi_ab_openentry($ab, $props[PR_SENT_REPRESENTING_ENTRYID]);


### PR DESCRIPTION
A user composing a new message gets **two entries in Sent Items** for it. The Outbox holds one, and the recipient receives one. The two entries differ in a single visible way: one shows the sender as `Surname Name<Surname .Name@domain.de>`, the other as `Surname Name<samaccountname>`. Replying is unaffected.
f
## Why

`submitMessage` decides whether a send is on behalf of somebody else by comparing two addresses as strings:

```php
strcasecmp((string) $reprEmail, (string) $reprSender) != 0
```

`PR_SENT_REPRESENTING_EMAIL_ADDRESS` against `PR_SENDER_EMAIL_ADDRESS`. On an ordinary send both name the sender, but not always in the same spelling: one carries the SMTP address and the other the logon name. `Surname .Name@domain.de` and `samaccountname` are the same person and the comparison says otherwise, so `$sendingAsDelegate` is set.

A few lines later that verdict is acted on:

```php
if ($sendingAsDelegate && ($saveBoth || $saveRepresentee)) {
```

and a copy of the message is written into the representee's Sent Items. For a message of one's own the representee is the sender, so the copy lands in the folder that already has one. Two entries, one message.

**Replies escape** because they carry the identity over from the message being answered, so both properties end up spelled alike and the comparison matches.

**It only shows with `zarafa/v1/contexts/mail/delegate_sent_items_style` set to `both` or `representee`.** The default is `delegate`, under which the wrong verdict has no visible effect, which is why this is not seen everywhere.

## The change

An address is treated as the sender's own when it matches any spelling of their identity — SMTP address, email address, or logon name — and a send counts as a delegate send only when the representing identity is *not* their own. Both places that reach the delegate branch ask the same question.

## Verified

`isOwnIdentity` is extracted from the file and run for real, with the session reporting `smtp=surename.name@domain.de` and `logon=samaccountname`. 8 assertions, all passing: both spellings are recognised as the user's own, in either case, and a different person is not — by address or by logon name. Empty and null are not own.

