### PR TITLE
settings: normalize PR_EC_USER_LANGUAGE via Language::resolveLanguage()

### DIFF
--- a/server/includes/core/class.settings.php
+++ b/server/includes/core/class.settings.php
@@ -328,7 +328,7 @@ class Settings {
 				}
 			}
 			if (isset($storeProps[PR_EC_USER_LANGUAGE])) {
-				$settings["settings"]["zarafa"]["v1"]["main"]["language"] = $storeProps[PR_EC_USER_LANGUAGE];
+				$settings["settings"]["zarafa"]["v1"]["main"]["language"] = Language::resolveLanguage($storeProps[PR_EC_USER_LANGUAGE]);
 			}
 			elseif (isset($_COOKIE['lang'])) {
 				$settings["settings"]["zarafa"]["v1"]["main"]["language"] = $_COOKIE['lang'];
@@ -346,7 +346,7 @@ class Settings {
 			 * while webapp loads.
 			 */
 			if (isset($storeProps[PR_EC_USER_LANGUAGE])) {
-				$settings["settings"]["zarafa"]["v1"]["main"]["language"] = $storeProps[PR_EC_USER_LANGUAGE];
+				$settings["settings"]["zarafa"]["v1"]["main"]["language"] = Language::resolveLanguage($storeProps[PR_EC_USER_LANGUAGE]);
 			}
 			elseif (isset($_COOKIE['lang'])) {
 				$settings["settings"]["zarafa"]["v1"]["main"]["language"] = $_COOKIE['lang'];
@@ -567,7 +567,7 @@ class Settings {
 		$store = $GLOBALS['mapisession']->getDefaultMessageStore();
 		$storeProps = mapi_getprops($store, [PR_EC_USER_LANGUAGE]);
 		if (!empty($storeProps[PR_EC_USER_LANGUAGE])) {
-			$lang = $storeProps[PR_EC_USER_LANGUAGE];
+			$lang = $Language->resolveLanguage($storeProps[PR_EC_USER_LANGUAGE]);
 		}
 		else {
 			$lang = $this->get('zarafa/v1/main/language', LANG);


### PR DESCRIPTION
## Problem

`grommunio-admin` stores a user's store language (`PR_EC_USER_LANGUAGE`) as a bare code such as `fr_FR`, matching the values listed in `grommunio-admin-api`'s `res/storelangs.json` (e.g. `{"code": "fr_FR", "name": "Français"}`).

grommunio-web's language directories on disk are named with the full locale suffix, e.g. `server/language/fr_FR.UTF-8/`, and `Language::is_language()` / `Language::setLanguage()` require an exact match against that directory name. `Language::resolveLanguage()` exists precisely to normalize a bare code into that form, and is already called on every other code path that determines the active language (login cookie, settings fallback in `getSessionSettings()`'s else-branch).

The three places in `class.settings.php` that read `PR_EC_USER_LANGUAGE` directly do not call `resolveLanguage()`:

- `retrieveSettings()`, two call sites
- `getSessionSettings()`

As a result, for any account whose store language was set to a bare code like `fr_FR` (i.e. via `grommunio-admin user modify --lang fr_FR`), `is_language('fr_FR')` fails silently (no directory named exactly `fr_FR`), translations are never loaded, and the UI falls back to English text.

This is also sticky: `getSessionSettings()` re-derives `$_SESSION['lang']` from this same raw value on *every* request, and re-persists it into the `zarafa/v1/main/language` webapp setting each time — so manually picking a different language in Settings gets silently overwritten again on the next page load.

## Fix

Call `Language::resolveLanguage()` on `PR_EC_USER_LANGUAGE` at all three read sites, matching the existing pattern used elsewhere in the same file.

## Testing

Reproduced on a live instance: accounts provisioned via `grommunio-admin user modify --lang fr_FR` were stuck in English regardless of the in-app Settings language picker. Applied this exact patch (verified against grommunio-web 3.19.240) and confirmed the UI now correctly loads and keeps the French translation.