### PR TITLE
login: optional sign-in button instead of the OIDC auto-redirect

### DIFF
--- a/client/resources/css/darkmode.css
+++ b/client/resources/css/darkmode.css
@@ -2670,6 +2670,24 @@ body.dark-mode #loading-mask #form-container #logo {
 	body.login #form-container #logo {
 		filter: invert(1) hue-rotate(180deg);
 	}
+
+	/* #0f70bd as text on the dark panel is roughly 2:1, so lighten the outlined
+	   OpenID Connect button rather than inheriting it. */
+	body.login>#form-container #oidcbutton {
+		color: #6cb6f0;
+		border-color: #6cb6f0;
+	}
+
+	body.login>#form-container #oidcbutton:hover,
+	body.login>#form-container #oidcbutton:active {
+		background-color: #6cb6f0;
+		border-color: #6cb6f0;
+		color: #1c1d21;
+	}
+
+	body.login>#form-container #oidcbutton:focus {
+		box-shadow: 0 0 0 2px rgba(108, 182, 240, 0.45);
+	}
 }
 
 /*=============================================================================

--- a/client/resources/css/external/login.css
+++ b/client/resources/css/external/login.css
@@ -198,6 +198,49 @@ body.login>#form-container #submitbutton:focus {
   box-shadow:0 0 0 1px #fff inset
 }
 
+/* Separator above the OpenID Connect button, drawn without text so it needs
+   no translation. */
+body.login>#form-container #oidc-login {
+  border-top:1px solid rgba(128,128,128,0.35);
+  margin:18px 0 0;
+  padding:6px 0 0
+}
+
+/* Same shape as #submitbutton, but an anchor, so it needs the box model and
+   text centering that the input element brings along by itself. */
+body.login>#form-container #oidcbutton {
+  display:block;
+  box-sizing:border-box;
+  background:transparent;
+  color:#0f70bd;
+  min-height:28px;
+  line-height:1.5;
+  border:1px solid #0f70bd;
+  border-radius: 25px;
+  padding:2px 9px;
+  width: 100%;
+  margin:12px 0 0;
+  text-align:center;
+  text-decoration:none;
+  overflow-wrap:anywhere
+}
+
+body.login>#form-container #oidcbutton:hover {
+  background-color:#0f70bd;
+  color:white;
+  cursor: pointer;
+}
+
+body.login>#form-container #oidcbutton:active {
+  background-color:#065fa5;
+  border-color:#065fa5;
+  color:white
+}
+
+body.login>#form-container #oidcbutton:focus {
+  box-shadow:0 0 0 2px rgba(15,112,189,0.4)
+}
+
 /* Screen reader only - visually hidden but accessible */
 .sr-only {
   position: absolute;

--- a/defaults.php
+++ b/defaults.php
@@ -152,6 +152,25 @@ if (!defined("ENABLE_REMOTE_USER_LOGIN")) {
 }
 
 /*
+ * When an OpenID Connect provider is configured, the login page redirects to it
+ * immediately. Set to false to show the login form with an additional sign-in
+ * button instead, so the provider is only used when the user picks it.
+ * Has no effect when no provider is configured or when DISABLE_KEYCLOAK is set.
+ */
+if (!defined("OIDC_AUTO_REDIRECT")) {
+	define("OIDC_AUTO_REDIRECT", true);
+}
+
+/*
+ * Label of the OpenID Connect sign-in button, e.g. "Sign in with Contoso".
+ * Leave empty to use the translated default. Only used when OIDC_AUTO_REDIRECT
+ * is false.
+ */
+if (!defined("OIDC_BUTTON_LABEL")) {
+	define("OIDC_BUTTON_LABEL", '');
+}
+
+/*
  * When set to false this disables the welcome screen shown to new users.
  */
 if (!defined("ENABLE_WELCOME_SCREEN")) {

--- a/server/includes/templates/login.php
+++ b/server/includes/templates/login.php
@@ -31,9 +31,14 @@
 
 	<?php
 		$keycloak = KeyCloak::getInstance();
-		if (!is_null($keycloak) && (!defined('DISABLE_KEYCLOAK') || !DISABLE_KEYCLOAK)) {
+		$oidcEnabled = !is_null($keycloak) && (!defined('DISABLE_KEYCLOAK') || !DISABLE_KEYCLOAK);
+		// login_url() mints a fresh state on every call, so build it once and
+		// reuse it for both the redirect and the button.
+		$oidcLoginUrl = $oidcEnabled ? $keycloak->login_url($keycloak->redirect_url) : '';
+		$oidcLabel = OIDC_BUTTON_LABEL !== '' ? OIDC_BUTTON_LABEL : _("Sign in with OpenID Connect");
+		if ($oidcEnabled && OIDC_AUTO_REDIRECT) {
 			?>
-	<meta http-equiv='Refresh' content="1;URL='<?php echo $keycloak->login_url($keycloak->redirect_url); ?>'"/>
+	<meta http-equiv='Refresh' content="1;URL='<?php echo $oidcLoginUrl; ?>'"/>
 	<?php
 					echo "<div id='form-container' class='loading' >";
 		}
@@ -59,6 +64,11 @@
 
 						<input id="submitbutton" class="button" type="submit" value="<?php echo _("Sign in"); ?>">
 					</form>
+					<?php if ($oidcEnabled && !OIDC_AUTO_REDIRECT) { ?>
+					<div id="oidc-login">
+						<a id="oidcbutton" class="button" href="<?php echo htmlspecialchars($oidcLoginUrl, ENT_QUOTES); ?>"><?php echo htmlspecialchars((string) $oidcLabel, ENT_QUOTES); ?></a>
+					</div>
+					<?php } ?>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Why

When an OpenID Connect provider is configured, the login page has only ever emitted a meta refresh to it:

```php
<meta http-equiv='Refresh' content="1;URL='<?php echo $keycloak->login_url($keycloak->redirect_url); ?>'"/>
```

There is no way to reach the credential form, and no way to decline the redirect. Two consequences in practice: a deployment that keeps local passwords working alongside the provider cannot expose both, and a user who logs out is handed straight back to the provider by the next page load.

## What changes

Two constants in `defaults.php`, next to `ENABLE_REMOTE_USER_LOGIN`:

- `OIDC_AUTO_REDIRECT`, default `true`. Keeps the redirect exactly as it is today, so nothing changes unless an admin opts in. Set to `false` and the login form renders normally with an additional sign-in link to the provider.
- `OIDC_BUTTON_LABEL`, default `''`. Overrides the button text so a deployment can name its provider, e.g. `Sign in with Contoso`. When empty the translated default `Sign in with OpenID Connect` is used. Only consulted when `OIDC_AUTO_REDIRECT` is `false`.

Both are inert when no provider is configured or when `DISABLE_KEYCLOAK` is set, so the existing kill switch still wins.

The credential form stays visible alongside the button rather than being replaced, since the provider is now one of two offered paths rather than the only one.

`login_url()` mints a fresh `state` parameter on every call, so the URL is built once and shared by the redirect and the button instead of being generated twice.

## Styling

The button reuses the shape of `#submitbutton` as an outlined variant, so the password form keeps the primary affordance. `#0f70bd` as text on the dark login panel (`rgba(50,51,56,1)`) is only about 2:1, so `darkmode.css` lightens it to `#6cb6f0` inside the existing `prefers-color-scheme: dark` login block rather than inheriting an unreadable colour. The separator above the button is drawn as a border, with no text, so it needs no translation.

## Testing

`server/includes/templates/login.php` was rendered with its surrounding globals stubbed, in php 8.3, across six configurations:

| case | expected | result |
|---|---|---|
| provider on, `OIDC_AUTO_REDIRECT=true` | meta refresh and `loading` class present, no button | as today, byte-identical |
| provider on, `auto=false` | no meta refresh, no `loading`, button and credential form both present | ok |
| provider on, `auto=false`, custom label | button carries the configured text | ok |
| label containing `& <b> "` | escaped, no markup injection | ok |
| no provider configured, `auto=false` | no button, no redirect, form only | ok |
| `DISABLE_KEYCLOAK=true`, `auto=false` | no button, no redirect | ok |

The same assertions were then run against the unmodified template to confirm they fail there, so the suite distinguishes patched from unpatched rather than passing regardless.
