### PR TITLE
attachment: drag and save several attachments at once

### DIFF
--- a/client/resources/css/darkmode.css
+++ b/client/resources/css/darkmode.css
@@ -3361,6 +3361,11 @@ body.dark-mode .preview-header-attachments .zarafa-attachment-link-over {
 	border-color: var(--dm-border-strong);
 }
 
+body.dark-mode .preview-header-attachments .zarafa-attachment-link.x-view-selected {
+	background-color: var(--dm-selected);
+	border-color: var(--dm-border-strong);
+}
+
 /* Loading mask */
 body.dark-mode .ext-el-mask-msg {
 	border-radius: 8px;

--- a/client/resources/css/darkmode.css
+++ b/client/resources/css/darkmode.css
@@ -3361,9 +3361,16 @@ body.dark-mode .preview-header-attachments .zarafa-attachment-link-over {
 	border-color: var(--dm-border-strong);
 }
 
-body.dark-mode .preview-header-attachments .zarafa-attachment-link.x-view-selected {
+/*
+ * Both selectors are needed. The rule above for #zarafa-mainpanel carries an
+ * ID, so it beats any number of classes: without the second line here the
+ * selection is invisible in dark mode everywhere the attachment box actually
+ * lives. Measured in the browser, not assumed.
+ */
+body.dark-mode .preview-header-attachments .zarafa-attachment-link.x-view-selected,
+body.dark-mode #zarafa-mainpanel .zarafa-attachment-link.x-view-selected {
 	background-color: var(--dm-selected);
-	border-color: var(--dm-border-strong);
+	border-color: var(--theme-primary-color);
 }
 
 /* Loading mask */

--- a/client/resources/css/grommunio.css
+++ b/client/resources/css/grommunio.css
@@ -2400,6 +2400,10 @@ span.preview-header-sender-image {
   background-color: #e4e7ec;
   border-color: #98a2b3; }
 
+.preview-header-attachments .zarafa-attachment-link.x-view-selected {
+  background-color: #d5e8f7;
+  border-color: #0f70bd; }
+
 .preview-header-task .preview-from .task-info-container span {
   min-width: 80px;
   padding-top: 5px;

--- a/client/zarafa/common/attachment/AttachmentFolderSaver.js
+++ b/client/zarafa/common/attachment/AttachmentFolderSaver.js
@@ -1,0 +1,270 @@
+Ext.namespace('Zarafa.common.attachment');
+
+/**
+ * @class Zarafa.common.attachment.AttachmentFolderSaver
+ * Writes attachments to a folder the user picks, through the File System Access
+ * API.
+ *
+ * This exists because of a limit on the drag: a drag can hand the operating
+ * system at most one file, so a selection of several cannot be dropped onto
+ * Explorer or the desktop (see
+ * {@link Zarafa.common.ui.messagepanel.AttachmentLinks#onAttachmentDragStart}).
+ * Asking for a folder is the one way a page can put several loose files on
+ * disk, and it is the counterpart of "Download all as ZIP" for the case where
+ * the user wants the files themselves rather than an archive of them.
+ *
+ * Availability matches the drag-out: <tt>showDirectoryPicker()</tt> is Chromium
+ * only and needs a secure context, so the menu item is hidden elsewhere rather
+ * than failing once it is used.
+ * @singleton
+ */
+Zarafa.common.attachment.AttachmentFolderSaver = {
+	/**
+	 * Characters which may not go into a file name. Windows rejects all of them,
+	 * and the picker rejects any name holding a path separator.
+	 * @property
+	 * @type RegExp
+	 */
+	// eslint-disable-next-line no-control-regex
+	invalidFileNameChars: /[\\/:*?"<>|\x00-\x1f]/g,
+
+	/**
+	 * How many times a name may be stepped over before giving up, so a folder
+	 * which somehow answers "exists" forever cannot spin.
+	 * @property
+	 * @type Number
+	 */
+	maxNameAttempts: 200,
+
+	/**
+	 * @return {Boolean} True when this browser can be asked for a folder
+	 */
+	isSupported: function()
+	{
+		return Ext.isFunction(window.showDirectoryPicker) && window.isSecureContext !== false;
+	},
+
+	/**
+	 * The attachments of a selection which can be written to disk. Embedded
+	 * messages are excluded for the same reason as in the drag: they are not
+	 * backed by a single downloadable file.
+	 * @param {Zarafa.core.data.IPMAttachmentRecord|Zarafa.core.data.IPMAttachmentRecord[]} records
+	 * @return {Zarafa.core.data.IPMAttachmentRecord[]} The writable attachments
+	 */
+	getSaveableRecords: function(records)
+	{
+		var list = Ext.isArray(records) ? records : [records];
+		var saveable = [];
+
+		for (var i = 0; i < list.length; i++) {
+			var record = list[i];
+			if (!record || !Ext.isFunction(record.getAttachmentUrl)) {
+				continue;
+			}
+			if (Ext.isFunction(record.isEmbeddedMessage) && record.isEmbeddedMessage()) {
+				continue;
+			}
+			if (Ext.isEmpty(record.getAttachmentUrl())) {
+				continue;
+			}
+
+			saveable.push(record);
+		}
+
+		return saveable;
+	},
+
+	/**
+	 * Asks for a folder and writes the given attachments into it.
+	 *
+	 * A full success is silent: the user chose the folder and the files are in
+	 * it. Anything which did not make it is named, so a partial result is never
+	 * mistaken for a complete one.
+	 *
+	 * @param {Zarafa.core.data.IPMAttachmentRecord[]} records The attachments to write
+	 */
+	save: function(records)
+	{
+		var self = this;
+		var saveable = this.getSaveableRecords(records);
+		if (Ext.isEmpty(saveable) || !this.isSupported()) {
+			return;
+		}
+
+		var written = 0;
+		var failed = [];
+
+		window.showDirectoryPicker({ mode: 'readwrite' }).then(function(dirHandle) {
+			// One after another: the names are resolved against what the folder
+			// already holds, so the writes cannot be independent, and a mailbox
+			// is no place to open a dozen parallel downloads.
+			var chain = Promise.resolve();
+			var taken = {};
+
+			saveable.forEach(function(record) {
+				chain = chain.then(function() {
+					return self.writeAttachment(dirHandle, record, taken).then(function() {
+						written++;
+					}, function() {
+						failed.push(record.get('name') || _('Untitled'));
+					});
+				});
+			});
+
+			return chain;
+		}).then(function() {
+			if (!Ext.isEmpty(failed)) {
+				self.showResult(written, failed);
+			}
+		}, function(err) {
+			// Dismissing the folder picker is a choice, not a failure.
+			if (err && err.name === 'AbortError') {
+				return;
+			}
+
+			self.showResult(written, failed);
+		});
+	},
+
+	/**
+	 * Fetches one attachment and writes it into the chosen folder under a name
+	 * which is free both within this run and in the folder itself. A write which
+	 * fails part way takes its own half-written file with it.
+	 * @param {FileSystemDirectoryHandle} dirHandle The folder chosen by the user
+	 * @param {Zarafa.core.data.IPMAttachmentRecord} record The attachment to write
+	 * @param {Object} taken The lower-cased names already used by this run
+	 * @return {Promise} Resolved once the file is closed
+	 * @private
+	 */
+	writeAttachment: function(dirHandle, record, taken)
+	{
+		var self = this;
+
+		return window.fetch(record.getAttachmentUrl(), { credentials: 'include' }).then(function(response) {
+			if (!response.ok) {
+				throw new Error('HTTP ' + response.status);
+			}
+
+			return response.blob();
+		}).then(function(blob) {
+			return self.reserveFileName(dirHandle, record.get('name'), taken).then(function(name) {
+				return dirHandle.getFileHandle(name, { create: true }).then(function(fileHandle) {
+					return fileHandle.createWritable();
+				}).then(function(writable) {
+					return writable.write(blob).then(function() {
+						return writable.close();
+					}, function(err) {
+						// Discard the writes and remove the entry this call
+						// created: an empty file carrying an attachment's name
+						// reads as a saved attachment and is not one.
+						return writable.abort().catch(function() {
+							// An unabortable stream still must not keep the file.
+						}).then(function() {
+							return dirHandle.removeEntry(name).catch(function() {
+								// Nothing more can be done about the leftover.
+							});
+						}).then(function() {
+							throw err;
+						});
+					});
+				});
+			});
+		});
+	},
+
+	/**
+	 * A file name which is free within this run and absent from the folder.
+	 *
+	 * The folder belongs to the user and may already hold a file of this name,
+	 * so a taken name is stepped over ("report (2).pdf") rather than written
+	 * through: <tt>getFileHandle</tt> with <tt>create</tt> would truncate their
+	 * file without a word.
+	 *
+	 * @param {FileSystemDirectoryHandle} dirHandle The folder chosen by the user
+	 * @param {String} rawName The attachment name as it arrived in the message
+	 * @param {Object} taken The lower-cased names already used by this run
+	 * @return {Promise} Resolved with the name to write
+	 * @private
+	 */
+	reserveFileName: function(dirHandle, rawName, taken)
+	{
+		var base = this.sanitizeFileName(rawName);
+		var dot = base.lastIndexOf('.');
+		var stem = dot > 0 ? base.substring(0, dot) : base;
+		var ext = dot > 0 ? base.substring(dot) : '';
+		var limit = this.maxNameAttempts;
+
+		var attempt = function(n) {
+			if (n > limit) {
+				return Promise.reject(new Error('no free file name for ' + base));
+			}
+
+			var name = n === 1 ? stem + ext : stem + ' (' + n + ')' + ext;
+			if (taken[name.toLowerCase()] === true) {
+				return attempt(n + 1);
+			}
+
+			return dirHandle.getFileHandle(name).then(function() {
+				// It resolved, so the folder already holds this name.
+				return attempt(n + 1);
+			}, function(err) {
+				if (err && err.name === 'NotFoundError') {
+					taken[name.toLowerCase()] = true;
+					return name;
+				}
+
+				throw err;
+			});
+		};
+
+		return attempt(1);
+	},
+
+	/**
+	 * Reduces an attachment name, which is sender controlled, to something a
+	 * folder will accept: the basename only, no character a file system rejects,
+	 * no leading dot and no trailing dot or space (Windows drops those, which
+	 * would silently change the name).
+	 * @param {String} name The attachment name
+	 * @return {String} A usable file name, never empty
+	 * @private
+	 */
+	sanitizeFileName: function(name)
+	{
+		var clean = String(name || '')
+			.replace(/^.*[\\/]/, '')
+			.replace(this.invalidFileNameChars, '_')
+			.replace(/^\.+/, '_')
+			.replace(/[. ]+$/, '')
+			.substring(0, 200);
+
+		return Ext.isEmpty(clean) ? _('Untitled') : clean;
+	},
+
+	/**
+	 * Names what did not reach the folder. Only ever shown when something
+	 * failed, so it always carries news.
+	 * @param {Number} written How many attachments were written
+	 * @param {String[]} failed The names which were not
+	 * @private
+	 */
+	showResult: function(written, failed)
+	{
+		var msg;
+		if (Ext.isEmpty(failed)) {
+			msg = _('The attachments could not be saved.');
+		} else {
+			msg = String.format(
+				ngettext('{0} attachment was saved. This one could not be: {1}',
+					'{0} attachments were saved. These could not be: {1}', written),
+				written, Ext.util.Format.htmlEncode(failed.join(', ')));
+		}
+
+		Ext.MessageBox.show({
+			title: _('Save attachments'),
+			msg: msg,
+			cls: Ext.MessageBox.ERROR_CLS,
+			buttons: Ext.MessageBox.OK
+		});
+	}
+};

--- a/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
+++ b/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
@@ -71,6 +71,12 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 			handler: this.onDownloadAllAsZip,
 			beforeShow: this.onDownloadZipBeforeShow
 		}, {
+			text: _('Save selection to folder'),
+			iconCls: 'icon_download',
+			scope: this,
+			handler: this.onSaveSelectionToFolder,
+			beforeShow: this.onSaveSelectionBeforeShow
+		}, {
 			text: _('Import to folder'),
 			iconCls: 'icon_import_attachment',
 			handler: this.onImportToFolder,
@@ -169,6 +175,26 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	 * @param {Zarafa.core.ui.menu.ConditionalItem} item context menu item
 	 * @param {Zarafa.core.data.IPMAttachmentRecord|Zarafa.core.data.IPMAttachmentRecord[]} records attachment record(s) on which context menu is shown
 	 */
+	onSaveSelectionBeforeShow: function(item, records)
+	{
+		var saver = Zarafa.common.attachment.AttachmentFolderSaver;
+
+		// This answers a need only a selection has: several loose files on disk,
+		// which neither the drag (one file at most) nor the ZIP (an archive of
+		// everything) gives. A single attachment is what "Download" is for, so
+		// the item stays out of the menu until there are several to write.
+		var visible = Ext.isArray(records) && saver.isSupported() &&
+			saver.getSaveableRecords(records).length > 1;
+
+		item.setVisible(visible);
+	},
+
+	/**
+	 * Function will be called before {@link Zarafa.common.attachment.ui.AttachmentContextMenu AttachmentContextMenu} is shown
+	 * so we can decide which item should be disabled.
+	 * @param {Zarafa.core.ui.menu.ConditionalItem} item context menu item
+	 * @param {Zarafa.core.data.IPMAttachmentRecord|Zarafa.core.data.IPMAttachmentRecord[]} records attachment record(s) on which context menu is shown
+	 */
 	onImportToFolderBeforeShow: function(item, records)
 	{
 		var record = this.getPrimaryRecord(records);
@@ -239,6 +265,17 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	onDownloadAllAsZip: function()
 	{
 		Zarafa.common.Actions.downloadAttachment(this.getPrimaryRecord(), true);
+	},
+
+	/**
+	 * Event handler which is called when the user selects the 'Save selection to
+	 * folder' item in the context menu. Writes the selected attachments as loose
+	 * files into a folder the user picks.
+	 * @private
+	 */
+	onSaveSelectionToFolder: function()
+	{
+		Zarafa.common.attachment.AttachmentFolderSaver.save(this.records);
 	},
 
 	/**

--- a/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
+++ b/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
@@ -81,13 +81,35 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	},
 
 	/**
+	 * The single attachment the per-item actions apply to.
+	 *
+	 * The menu is opened with a bare record for a plain right-click and with an
+	 * array when the click lands inside a selection of several, see
+	 * {@link Zarafa.common.ui.messagepanel.AttachmentLinks#getGestureRecords}.
+	 * Every item here acts on one attachment, so they all resolve through this;
+	 * an item that acts on the whole selection reads {@link #records} itself.
+	 *
+	 * @param {Zarafa.core.data.IPMAttachmentRecord|Zarafa.core.data.IPMAttachmentRecord[]} records
+	 * The records the menu was opened with, defaulting to the menu's own
+	 * @return {Zarafa.core.data.IPMAttachmentRecord} The record to act on
+	 * @private
+	 */
+	getPrimaryRecord: function(records)
+	{
+		var candidate = Ext.isDefined(records) ? records : this.records;
+		return Ext.isArray(candidate) ? candidate[0] : candidate;
+	},
+
+	/**
 	 * Function will be called before {@link Zarafa.common.attachment.ui.AttachmentContextMenu AttachmentContextMenu} is shown
 	 * so we can decide which item should be disabled.
 	 * @param {Zarafa.core.ui.menu.ConditionalItem} item context menu item
-	 * @param {Zarafa.core.data.IPMAttachmentRecord} record attachment record on which context menu is shown
+	 * @param {Zarafa.core.data.IPMAttachmentRecord|Zarafa.core.data.IPMAttachmentRecord[]} records attachment record(s) on which context menu is shown
 	 */
-	onPreviewBeforeShow: function(item, record)
+	onPreviewBeforeShow: function(item, records)
 	{
+		var record = this.getPrimaryRecord(records);
+
 		if (!Zarafa.common.Actions.isFilePreviewerEnabled()) {
 			item.setVisible(false);
 			return;
@@ -108,22 +130,23 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	 * Function will be called before {@link Zarafa.common.attachment.ui.AttachmentContextMenu AttachmentContextMenu} is shown
 	 * so we can decide which item should be disabled.
 	 * @param {Zarafa.core.ui.menu.ConditionalItem} item context menu item
-	 * @param {Zarafa.core.data.IPMAttachmentRecord} record attachment record on which context menu is shown
+	 * @param {Zarafa.core.data.IPMAttachmentRecord|Zarafa.core.data.IPMAttachmentRecord[]} records attachment record(s) on which context menu is shown
 	 */
-	onDownloadBeforeShow: function(item, record)
+	onDownloadBeforeShow: function(item, records)
 	{
 		// embedded messages can not be downloaded
-		item.setDisabled(record.isEmbeddedMessage());
+		item.setDisabled(this.getPrimaryRecord(records).isEmbeddedMessage());
 	},
 
 	/**
 	 * Function will be called before {@link Zarafa.common.attachment.ui.AttachmentContextMenu AttachmentContextMenu} is shown
 	 * so we can decide which item should be disabled.
 	 * @param {Zarafa.core.ui.menu.ConditionalItem} item context menu item
-	 * @param {Zarafa.core.data.IPMAttachmentRecord} record attachment record on which context menu is shown
+	 * @param {Zarafa.core.data.IPMAttachmentRecord|Zarafa.core.data.IPMAttachmentRecord[]} records attachment record(s) on which context menu is shown
 	 */
-	onDownloadZipBeforeShow: function(item, record)
+	onDownloadZipBeforeShow: function(item, records)
 	{
+		var record = this.getPrimaryRecord(records);
 		var normalAttachmentCounter = 0;
 		// Check if there is more than one normal attachments.
 		// Here, 'query' method of Ext.data.Store is useless in case where there is same id(-1) of all the unsaved attachments.
@@ -144,10 +167,11 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	 * Function will be called before {@link Zarafa.common.attachment.ui.AttachmentContextMenu AttachmentContextMenu} is shown
 	 * so we can decide which item should be disabled.
 	 * @param {Zarafa.core.ui.menu.ConditionalItem} item context menu item
-	 * @param {Zarafa.core.data.IPMAttachmentRecord} record attachment record on which context menu is shown
+	 * @param {Zarafa.core.data.IPMAttachmentRecord|Zarafa.core.data.IPMAttachmentRecord[]} records attachment record(s) on which context menu is shown
 	 */
-	onImportToFolderBeforeShow: function(item, record)
+	onImportToFolderBeforeShow: function(item, records)
 	{
+		var record = this.getPrimaryRecord(records);
 		var store = record.getStore();
 		var parentRecord = store.getParentRecord();
 		item.setDisabled(!record.canBeImported() || parentRecord.phantom);
@@ -161,7 +185,9 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	onImportToFolderAfterRender: function(item)
 	{
 		var serverConfig = container.getServerConfig();
-		var attachRecord = this.getRecords();
+		// 'this' is the menu item here, so the records are reached through the
+		// root menu, which normalises a selection down to a single attachment.
+		var attachRecord = this.getRootMenu().getPrimaryRecord();
 		if (!serverConfig.isVCfImportSupported() && attachRecord.isVCFAttachment()) {
 			var tooltip = _('In order to use the vCard import feature, upgrade your Gromox to version 0 or higher.');
 			this.setTooltipOnImportButton(this.getEl(), tooltip);
@@ -192,7 +218,7 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	{
 		//should already have a component that has won the bid
 		//invoke that component to open the preview
-		Zarafa.core.data.UIFactory.openViewRecord(this.records, {modal: true, autoResize: true});
+		Zarafa.core.data.UIFactory.openViewRecord(this.getPrimaryRecord(), {modal: true, autoResize: true});
 	},
 
 	/**
@@ -202,7 +228,7 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	 */
 	onDownloadItem: function()
 	{
-		Zarafa.common.Actions.downloadAttachment(this.records);
+		Zarafa.common.Actions.downloadAttachment(this.getPrimaryRecord());
 	},
 
 	/**
@@ -212,7 +238,7 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	 */
 	onDownloadAllAsZip: function()
 	{
-		Zarafa.common.Actions.downloadAttachment(this.records, true);
+		Zarafa.common.Actions.downloadAttachment(this.getPrimaryRecord(), true);
 	},
 
 	/**
@@ -222,7 +248,7 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	 */
 	onImportToFolder: function()
 	{
-		Zarafa.common.Actions.importToFolder(this.records);
+		Zarafa.common.Actions.importToFolder(this.getPrimaryRecord());
 	}
 });
 

--- a/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
+++ b/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
@@ -87,6 +87,13 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	},
 
 	/**
+	 * @cfg {Zarafa.core.data.IPMAttachmentRecord} primaryRecord The attachment the
+	 * pointer was on when the menu was opened. Optional; when absent the first of
+	 * {@link #records} is used. See {@link #getPrimaryRecord}.
+	 */
+	primaryRecord: undefined,
+
+	/**
 	 * The single attachment the per-item actions apply to.
 	 *
 	 * The menu is opened with a bare record for a plain right-click and with an
@@ -102,6 +109,13 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	 */
 	getPrimaryRecord: function(records)
 	{
+		// The opener names the attachment the pointer was on. Falling back to
+		// the first of the selection would make a right-click inside a selection
+		// act on a different attachment than the one that was clicked.
+		if (this.primaryRecord) {
+			return this.primaryRecord;
+		}
+
 		var candidate = Ext.isDefined(records) ? records : this.records;
 		return Ext.isArray(candidate) ? candidate[0] : candidate;
 	},

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -90,7 +90,7 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 			anchor: '100%',
 			iconCls: 'icon_paperclip',
 			cls: 'preview-header-attachments',
-			multiSelect: false,
+			multiSelect: true,
 			overClass: 'zarafa-attachment-link-over',
 			itemSelector: 'span.zarafa-attachment-link',
 			tpl: new Ext.XTemplate(
@@ -769,6 +769,12 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	/**
 	 * Called when the {@link #click} event is fired. This will
 	 * {@link Zarafa.core.data.UIFactory#openViewRecord open} the selected attachment
+	 *
+	 * A click carrying a modifier is a selection gesture and must not open
+	 * anything: {@link Ext.DataView#doMultiSelection} has already extended or
+	 * reduced the selection by the time this runs, and opening the attachment on
+	 * top of that would make a selection impossible to build.
+	 *
 	 * @param {Ext.DataView} dataview Reference to this object
 	 * @param {Number} index
 	 * @param {HTMLElement} node The target HTML element
@@ -783,12 +789,52 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 			return;
 		}
 
+		if (evt && (evt.ctrlKey || evt.shiftKey || evt.metaKey)) {
+			return;
+		}
+
 		var attachment = dataview.getRecord(node);
 		Zarafa.common.Actions.openAttachmentRecord(attachment);
 	},
+
+	/**
+	 * The records a gesture on <tt>node</tt> applies to: the whole selection when
+	 * that node is part of a selection of several, and otherwise only the node
+	 * itself, leaving any selection untouched.
+	 *
+	 * This is the behaviour of Explorer and Outlook, and it is what lets a drag
+	 * or a context menu act on several attachments without a visible selection
+	 * control: the user builds the selection with ctrl/shift and then starts the
+	 * gesture on one of the selected items.
+	 *
+	 * @param {HTMLElement} node The node the gesture started on
+	 * @return {Zarafa.core.data.IPMAttachmentRecord[]} The records, possibly empty
+	 * @private
+	 */
+	getGestureRecords: function(node)
+	{
+		var record = this.getRecord(node);
+		if (!record) {
+			return [];
+		}
+
+		if (this.getSelectionCount() > 1 && this.isSelected(node)) {
+			var selected = this.getSelectedRecords();
+			if (!Ext.isEmpty(selected)) {
+				return selected;
+			}
+		}
+
+		return [record];
+	},
+
 	/**
 	 * Called when user right-clicks on an item in {@link Zarafa.common.ui.messagepanel.AttachmentLinks}
 	 * invokes {@link Zarafa.core.data.UIFactory#openDefaultContextMenu} with the selected {@link Zarafa.core.data.IPMRecord}
+	 *
+	 * Passes an array only when the gesture covers several attachments, so a
+	 * plain right-click hands the menu exactly what it has always been handed.
+	 *
 	 * @param {Ext.DataView} dataView DataView from which the event comes
 	 * @param {Number} index
 	 * @param {HTMLElement} node HTML node from which the event originates
@@ -797,7 +843,12 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	 */
 	onNodeContextMenu: function(dataView, index, node, evt)
 	{
-		Zarafa.core.data.UIFactory.openDefaultContextMenu(dataView.getRecord(node), {
+		var records = this.getGestureRecords(node);
+		if (Ext.isEmpty(records)) {
+			return;
+		}
+
+		Zarafa.core.data.UIFactory.openDefaultContextMenu(records.length > 1 ? records : records[0], {
 			position: evt.getXY(),
 			model: this.model
 		});

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -135,6 +135,7 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 		// Drag-out prefetch state, initialised once so the cache is always an object.
 		this.attachmentPayloadCache = {};
 		this.activePrefetches = [];
+		this.prefetchQueue = [];
 		this.pendingPrefetchCount = 0;
 		this.prefetchGeneration = 0;
 		this.payloadCacheSeq = 0;
@@ -143,6 +144,7 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 			'contextmenu': this.onNodeContextMenu,
 			'click': this.onAttachmentClicked,
 			'render': this.onRenderRegisterDragOut,
+			'selectionchange': this.onSelectionChangePrefetch,
 			scope: this
 		});
 	},
@@ -311,6 +313,10 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 		}
 
 		if (this.pendingPrefetchCount >= this.maxConcurrentPrefetch) {
+			// Queue instead of dropping it. A drag over a selection needs every
+			// one of its payloads, and nothing would ever start the ones beyond
+			// the concurrency limit again.
+			this.queuePrefetch(record, key);
 			return;
 		}
 
@@ -402,7 +408,108 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 					self.activePrefetches.splice(idx, 1);
 				}
 			}
+
+			self.drainPrefetchQueue();
 		});
+	},
+
+	/**
+	 * Remembers an attachment whose prefetch could not be started because
+	 * {@link #maxConcurrentPrefetch} downloads are already in flight, so
+	 * {@link #drainPrefetchQueue} can start it when a slot frees up. Ignores an
+	 * attachment already waiting.
+	 * @param {Zarafa.core.data.IPMAttachmentRecord} record The attachment record
+	 * @param {String} key Its {@link #getAttachmentCacheKey cache key}
+	 * @private
+	 */
+	queuePrefetch: function(record, key)
+	{
+		for (var i = 0; i < this.prefetchQueue.length; i++) {
+			if (this.getAttachmentCacheKey(this.prefetchQueue[i]) === key) {
+				return;
+			}
+		}
+
+		this.prefetchQueue.push(record);
+	},
+
+	/**
+	 * Starts queued prefetches while there is a free slot. The queue only ever
+	 * shrinks here: entries are taken off it before being started, and one is
+	 * queued again only from a state where every slot is busy.
+	 * @private
+	 */
+	drainPrefetchQueue: function()
+	{
+		while (!Ext.isEmpty(this.prefetchQueue) && this.pendingPrefetchCount < this.maxConcurrentPrefetch) {
+			this.prefetchAttachmentFile(this.prefetchQueue.shift());
+		}
+	},
+
+	/**
+	 * Event handler for {@link #selectionchange}. Starts fetching the payloads of
+	 * a multiple selection, so that dragging it out finds them ready: the drag
+	 * itself cannot wait for a download, and {@link #onAttachmentDragStart} hands
+	 * over a selection only when every payload is present.
+	 * @private
+	 */
+	onSelectionChangePrefetch: function()
+	{
+		if (!this.isDragOutEmbedEnabled() || this.getSelectionCount() < 2) {
+			return;
+		}
+
+		var records = this.getSelectedRecords();
+		for (var i = 0; i < records.length; i++) {
+			if (this.isDraggableAttachment(records[i])) {
+				this.prefetchAttachmentFile(records[i]);
+			}
+		}
+	},
+
+	/**
+	 * Whether an attachment can take part in a drag out of grommunio Web.
+	 * Embedded messages cannot: they are not backed by a single downloadable
+	 * file, so they have neither a download URL nor a payload.
+	 * @param {Zarafa.core.data.IPMAttachmentRecord} record The attachment record
+	 * @return {Boolean} True if the attachment can be dragged out
+	 * @private
+	 */
+	isDraggableAttachment: function(record)
+	{
+		return !!record && !(Ext.isFunction(record.isEmbeddedMessage) && record.isEmbeddedMessage());
+	},
+
+	/**
+	 * Collects the cached payloads of the given attachments, all of them or none.
+	 *
+	 * A payload cannot be fetched from within <tt>dragstart</tt>, which is
+	 * synchronous, so handing over the subset that happens to be ready would drop
+	 * the rest of the selection without telling anyone — a drop that looks
+	 * complete and is not. When one is missing its fetch is started instead, so a
+	 * later drag of the same selection carries everything.
+	 *
+	 * @param {Zarafa.core.data.IPMAttachmentRecord[]} records The attachments to be dragged
+	 * @return {String[]} The payloads as JSON strings, or null when incomplete
+	 * @private
+	 */
+	collectDragPayloads: function(records)
+	{
+		var payloads = [];
+		var complete = true;
+
+		for (var i = 0; i < records.length; i++) {
+			var entry = this.attachmentPayloadCache[this.getAttachmentCacheKey(records[i])];
+			if (entry && entry.payload) {
+				this.touchCacheEntry(entry);
+				payloads.push(entry.payload);
+			} else {
+				complete = false;
+				this.prefetchAttachmentFile(records[i]);
+			}
+		}
+
+		return complete ? payloads : null;
 	},
 
 	/**
@@ -458,13 +565,26 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	 *   {@link #prefetchAttachmentFile prefetched}, the payload is also exposed
 	 *   under the custom {@link #attachmentDragOutType} MIME type as a JSON string
 	 *   <tt>{name, type, size, data(base64)}</tt>, so a cooperating receiving web
-	 *   application can reconstruct the file on drop.
+	 *   application can reconstruct the file on drop. Several attachments travel
+	 *   as an array of those objects, which the reader has always accepted.
 	 *
 	 * The two do not conflict: when a web page's drop handler calls
 	 * <tt>preventDefault()</tt> (as a drop zone must), the browser hands over the
 	 * custom payload and does NOT download. The <tt>DownloadURL</tt> download only
 	 * happens when the drop target does not accept the drop, i.e. the operating
 	 * system (Explorer/desktop) or a page area without a drop handler.
+	 *
+	 * 🛑 The two are not equally capable, and that governs what a multiple
+	 * selection can do. A drag can hand the operating system at most ONE file:
+	 * Chromium's drop data holds a single optional <tt>DownloadUrlMetadata</tt>
+	 * (<tt>content/public/common/drop_data.h</tt>), and its multi-valued file list
+	 * is the inbound direction, which is why dropping many files INTO the browser
+	 * works and the reverse does not. The custom type has no such limit because
+	 * the receiving page reconstructs the files itself. So a selection of several
+	 * is offered to a cooperating web application and NOT to the operating
+	 * system: writing the one attachment under the cursor would look like it had
+	 * written them all. Several files reach the disk through the context menu's
+	 * "Save selection to folder" instead.
 	 *
 	 * @param {Ext.EventObject} evt The native event wrapped by Ext.
 	 * @private
@@ -480,14 +600,19 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 			return;
 		}
 
-		var record = this.getRecord(node);
-		if (!record) {
-			return;
+		// Embedded messages take no part in the drag. Dropping them out of a
+		// mixed selection keeps the rest of it draggable, and a gesture that
+		// covers nothing else stays a plain (in-app) drag.
+		var gesture = this.getGestureRecords(node);
+		var records = [];
+		var i;
+		for (i = 0; i < gesture.length; i++) {
+			if (this.isDraggableAttachment(gesture[i])) {
+				records.push(gesture[i]);
+			}
 		}
 
-		// Embedded messages are not backed by a single downloadable file, so
-		// leave the drag as a plain (in-app) drag for those.
-		if (Ext.isFunction(record.isEmbeddedMessage) && record.isEmbeddedMessage()) {
+		if (Ext.isEmpty(records)) {
 			return;
 		}
 
@@ -497,32 +622,24 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 			return;
 		}
 
-		var name = record.get('name') || _('Untitled');
-		var mimeType = record.get('filetype') || 'application/octet-stream';
-
-		// DownloadURL requires a fully qualified URL.
-		var url = record.getAttachmentUrl();
-		if (!Ext.isEmpty(url)) {
-			url = new URL(url, window.location.href).href;
-		}
+		var multiple = records.length > 1;
 
 		// (1) Custom type for dropping into a cooperating web application. Only
-		// available when the feature is enabled and the payload was prefetched.
+		// available when the feature is enabled and every payload was prefetched.
 		var haveCustomPayload = false;
 		if (this.isDragOutEmbedEnabled()) {
-			var entry = this.attachmentPayloadCache[this.getAttachmentCacheKey(record)];
-			if (entry && entry.payload) {
-				this.touchCacheEntry(entry);
+			var payloads = this.collectDragPayloads(records);
+			if (payloads) {
 				try {
-					dataTransfer.setData(this.attachmentDragOutType, entry.payload);
+					// The cached payloads are JSON strings already, so the array
+					// is assembled textually rather than by decoding and
+					// re-encoding megabytes of base64 during dragstart.
+					dataTransfer.setData(this.attachmentDragOutType,
+						multiple ? '[' + payloads.join(',') + ']' : payloads[0]);
 					haveCustomPayload = true;
 				} catch (e) {
 					// Browser rejected the custom type; ignore.
 				}
-			} else {
-				// Not prefetched yet (or in-flight): start fetching so a
-				// subsequent drag can embed the payload.
-				this.prefetchAttachmentFile(record);
 			}
 		}
 
@@ -530,20 +647,39 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 		// Windows Explorer / desktop). This coexists with the custom type: a web
 		// drop zone that calls preventDefault() receives the custom payload and
 		// no download is triggered; only the OS (which cannot honour the custom
-		// type) uses the DownloadURL to save the file.
+		// type) uses the DownloadURL to save the file. Offered for a single
+		// attachment only, see the note above.
 		try {
-			if (!Ext.isEmpty(url)) {
-				// Name and MIME type are sender-controlled; ':' is the DownloadURL
-				// field separator, so strip it from both or a crafted value could
-				// hijack the URL (everything after the second ':' is the URL).
-				var safeName = String(name).replace(/[\r\n]+/g, ' ').replace(/:/g, '_');
-				var baseMime = String(mimeType).split(';')[0].trim();
-				var safeMime = /^[\w.+-]+\/[\w.+-]+$/.test(baseMime) ? baseMime : 'application/octet-stream';
-				dataTransfer.setData('DownloadURL', safeMime + ':' + safeName + ':' + url);
-				dataTransfer.setData('text/uri-list', url);
+			if (!multiple) {
+				var record = records[0];
+				var name = record.get('name') || _('Untitled');
+				var mimeType = record.get('filetype') || 'application/octet-stream';
+
+				// DownloadURL requires a fully qualified URL.
+				var url = record.getAttachmentUrl();
+				if (!Ext.isEmpty(url)) {
+					url = new URL(url, window.location.href).href;
+
+					// Name and MIME type are sender-controlled; ':' is the DownloadURL
+					// field separator, so strip it from both or a crafted value could
+					// hijack the URL (everything after the second ':' is the URL).
+					var safeName = String(name).replace(/[\r\n]+/g, ' ').replace(/:/g, '_');
+					var baseMime = String(mimeType).split(';')[0].trim();
+					var safeMime = /^[\w.+-]+\/[\w.+-]+$/.test(baseMime) ? baseMime : 'application/octet-stream';
+					dataTransfer.setData('DownloadURL', safeMime + ':' + safeName + ':' + url);
+					dataTransfer.setData('text/uri-list', url);
+				}
+
+				// A human-readable label; useful when dropping onto a text field.
+				dataTransfer.setData('text/plain', haveCustomPayload || Ext.isEmpty(url) ? name : url);
+			} else {
+				var names = [];
+				for (i = 0; i < records.length; i++) {
+					names.push(records[i].get('name') || _('Untitled'));
+				}
+				dataTransfer.setData('text/plain', names.join('\n'));
 			}
-			// A human-readable label; useful when dropping onto a text field.
-			dataTransfer.setData('text/plain', haveCustomPayload || Ext.isEmpty(url) ? name : url);
+
 			dataTransfer.effectAllowed = 'copyLink';
 		} catch (e) {
 			// Ignore browsers that reject one of the data types.
@@ -621,6 +757,7 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 		// fresh; fetches that settle afterwards skip their bookkeeping.
 		this.prefetchGeneration = (this.prefetchGeneration || 0) + 1;
 		this.pendingPrefetchCount = 0;
+		this.prefetchQueue = [];
 
 		if (this.activePrefetches) {
 			for (var i = 0; i < this.activePrefetches.length; i++) {

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -990,8 +990,16 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 			return;
 		}
 
-		Zarafa.core.data.UIFactory.openDefaultContextMenu(records[0], {
-			records: records.length > 1 ? records : records[0],
+		// `primaryRecord` is the attachment the pointer was actually on. Every
+		// item except "Save selection to folder" acts on one attachment, and
+		// without this they would act on the first of the selection instead of
+		// the one that was clicked: measured, right-clicking the third of three
+		// selected and choosing Download downloaded the first.
+		var record = this.getRecord(node);
+
+		Zarafa.core.data.UIFactory.openDefaultContextMenu(record, {
+			records: records.length > 1 ? records : record,
+			primaryRecord: record,
 			position: evt.getXY(),
 			model: this.model
 		});

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -580,11 +580,14 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	 * (<tt>content/public/common/drop_data.h</tt>), and its multi-valued file list
 	 * is the inbound direction, which is why dropping many files INTO the browser
 	 * works and the reverse does not. The custom type has no such limit because
-	 * the receiving page reconstructs the files itself. So a selection of several
-	 * is offered to a cooperating web application and NOT to the operating
-	 * system: writing the one attachment under the cursor would look like it had
-	 * written them all. Several files reach the disk through the context menu's
-	 * "Save selection to folder" instead.
+	 * the receiving page reconstructs the files itself.
+	 *
+	 * A selection of several therefore travels as two different things at once:
+	 * the loose files under the custom type, and, for the operating system, a
+	 * single ZIP of exactly that selection. One file is all the OS will take, so
+	 * it gets the one file that holds all of them — the one attachment under the
+	 * cursor would instead look like it had written them all. Loose files on disk
+	 * come from the context menu's "Save selection to folder".
 	 *
 	 * @param {Ext.EventObject} evt The native event wrapped by Ext.
 	 * @private
@@ -647,23 +650,25 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 		// Windows Explorer / desktop). This coexists with the custom type: a web
 		// drop zone that calls preventDefault() receives the custom payload and
 		// no download is triggered; only the OS (which cannot honour the custom
-		// type) uses the DownloadURL to save the file. Offered for a single
-		// attachment only, see the note above.
+		// type) uses the DownloadURL to save the file. One attachment goes as
+		// itself, several go as one ZIP of exactly that selection.
 		try {
+			var name, url, safeName;
+
 			if (!multiple) {
 				var record = records[0];
-				var name = record.get('name') || _('Untitled');
+				name = record.get('name') || _('Untitled');
 				var mimeType = record.get('filetype') || 'application/octet-stream';
 
 				// DownloadURL requires a fully qualified URL.
-				var url = record.getAttachmentUrl();
+				url = record.getAttachmentUrl();
 				if (!Ext.isEmpty(url)) {
 					url = new URL(url, window.location.href).href;
 
 					// Name and MIME type are sender-controlled; ':' is the DownloadURL
 					// field separator, so strip it from both or a crafted value could
 					// hijack the URL (everything after the second ':' is the URL).
-					var safeName = String(name).replace(/[\r\n]+/g, ' ').replace(/:/g, '_');
+					safeName = String(name).replace(/[\r\n]+/g, ' ').replace(/:/g, '_');
 					var baseMime = String(mimeType).split(';')[0].trim();
 					var safeMime = /^[\w.+-]+\/[\w.+-]+$/.test(baseMime) ? baseMime : 'application/octet-stream';
 					dataTransfer.setData('DownloadURL', safeMime + ':' + safeName + ':' + url);
@@ -673,6 +678,17 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 				// A human-readable label; useful when dropping onto a text field.
 				dataTransfer.setData('text/plain', haveCustomPayload || Ext.isEmpty(url) ? name : url);
 			} else {
+				// The archive is built by the server from the attachment numbers
+				// the URL names, so the drop costs nothing until it happens.
+				url = this.store.getSelectionZipUrl(records);
+				if (!Ext.isEmpty(url)) {
+					url = new URL(url, window.location.href).href;
+					name = this.getSelectionZipName();
+					safeName = String(name).replace(/[\r\n]+/g, ' ').replace(/:/g, '_');
+					dataTransfer.setData('DownloadURL', 'application/zip:' + safeName + ':' + url);
+					dataTransfer.setData('text/uri-list', url);
+				}
+
 				var names = [];
 				for (i = 0; i < records.length; i++) {
 					names.push(records[i].get('name') || _('Untitled'));
@@ -684,6 +700,26 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 		} catch (e) {
 			// Ignore browsers that reject one of the data types.
 		}
+	},
+
+	/**
+	 * The file name for the ZIP a multiple selection is dragged out as.
+	 *
+	 * It mirrors what <tt>download_attachment.php</tt> puts in the
+	 * <tt>Content-Disposition</tt> header — the word "Attachments", a space, and
+	 * the message subject with everything outside <tt>[a-z0-9 ()]</tt> replaced —
+	 * so the file the operating system writes carries the name the server would
+	 * have given it.
+	 *
+	 * @return {String} The archive file name
+	 * @private
+	 */
+	getSelectionZipName: function()
+	{
+		var parentRecord = this.store && Ext.isFunction(this.store.getParentRecord) ? this.store.getParentRecord() : null;
+		var subject = parentRecord ? (parentRecord.get('subject') || '') : '';
+
+		return _('Attachments') + ' ' + String(subject).replace(/[^a-z0-9 ()]/gi, '_') + '.zip';
 	},
 
 	/**

--- a/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
+++ b/client/zarafa/common/ui/messagepanel/AttachmentLinks.js
@@ -969,8 +969,13 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 	 * Called when user right-clicks on an item in {@link Zarafa.common.ui.messagepanel.AttachmentLinks}
 	 * invokes {@link Zarafa.core.data.UIFactory#openDefaultContextMenu} with the selected {@link Zarafa.core.data.IPMRecord}
 	 *
-	 * Passes an array only when the gesture covers several attachments, so a
-	 * plain right-click hands the menu exactly what it has always been handed.
+	 * 🛑 The selection is passed in the config, not as the first argument.
+	 * {@link Zarafa.core.data.UIFactory#openContextMenu} first asks the plugins
+	 * to bid for a component to show, and they bid on a single record: handing
+	 * that call an array makes every bid fail, whereupon it returns silently and
+	 * no menu opens at all. So the bid is given one record, exactly as before,
+	 * and `records` rides in the config, which <tt>Ext.applyIf</tt> then leaves
+	 * alone. Measured in the browser after a multiple selection opened nothing.
 	 *
 	 * @param {Ext.DataView} dataView DataView from which the event comes
 	 * @param {Number} index
@@ -985,7 +990,8 @@ Zarafa.common.ui.messagepanel.AttachmentLinks = Ext.extend(Ext.DataView, {
 			return;
 		}
 
-		Zarafa.core.data.UIFactory.openDefaultContextMenu(records.length > 1 ? records : records[0], {
+		Zarafa.core.data.UIFactory.openDefaultContextMenu(records[0], {
+			records: records.length > 1 ? records : records[0],
 			position: evt.getXY(),
 			model: this.model
 		});

--- a/client/zarafa/core/data/IPMAttachmentStore.js
+++ b/client/zarafa/core/data/IPMAttachmentStore.js
@@ -129,6 +129,44 @@ Zarafa.core.data.IPMAttachmentStore = Ext.extend(Zarafa.core.data.MAPISubStore, 
 	},
 
 	/**
+	 * Builds the URL which downloads exactly the given attachments as one ZIP,
+	 * rather than every attachment of the message as {@link #getAttachmentUrl}
+	 * with <tt>allAsZip</tt> does.
+	 *
+	 * Returns '' when the selection cannot be expressed this way, which is the
+	 * case for an attachment that is not saved yet: those are identified by a
+	 * temporary name rather than by an attachment number, so the server cannot
+	 * be asked for them by number. Returning nothing is deliberate — an archive
+	 * silently missing one of the chosen files is worse than none at all.
+	 *
+	 * @param {Zarafa.core.data.IPMAttachmentRecord[]} attachmentRecords The attachments to archive
+	 * @return {String} URL for downloading them as a single ZIP, or ''
+	 */
+	getSelectionZipUrl: function(attachmentRecords)
+	{
+		if (Ext.isEmpty(attachmentRecords)) {
+			return '';
+		}
+
+		var attachNums = [];
+		for (var i = 0, len = attachmentRecords.length; i < len; i++) {
+			var attachNum = attachmentRecords[i].get('attach_num');
+			if (!Ext.isNumber(attachNum) || attachNum === -1) {
+				return '';
+			}
+
+			attachNums.push(attachNum);
+		}
+
+		var url = this.getAttachmentUrl(attachmentRecords[0], true);
+		for (i = 0; i < attachNums.length; i++) {
+			url = Ext.urlAppend(url, 'selectedAttachNum[]=' + encodeURIComponent(attachNums[i]));
+		}
+
+		return url;
+	},
+
+	/**
 	 * Builds and returns attachment URL to download inline images/attachments,
 	 * it uses {@link Zarafa.core.data.IPMRecord IPMRecord} to get store and message entryids.
 	 * @param {Zarafa.core.data.IPMAttachmentRecord} attachmentRecord Attachment record.

--- a/server/includes/download_attachment.php
+++ b/server/includes/download_attachment.php
@@ -39,6 +39,13 @@ class DownloadAttachment extends DownloadBase {
 	private $attachCid;
 
 	/**
+	 * Attachment numbers a ZIP request is restricted to. Empty means every attachment of the message,
+	 * which is what 'AllAsZip' has always done; a non-empty list narrows the archive to exactly those
+	 * attachments, which is how a selection of several is downloaded as one file.
+	 */
+	private $selectedAttachNum;
+
+	/**
 	 * A string that will be initialized with grommunio Web-specific and common-for-all file name for ZIP file.
 	 */
 	private $zipFileName;
@@ -88,6 +95,7 @@ class DownloadAttachment extends DownloadBase {
 	public function __construct() {
 		$this->contentDispositionType = 'attachment';
 		$this->attachNum = [];
+		$this->selectedAttachNum = [];
 		$this->attachCid = false;
 		$this->zipFileName = _('Attachments') . '%s.zip';
 		$this->messageSubject = '';
@@ -143,6 +151,21 @@ class DownloadAttachment extends DownloadBase {
 				}
 				else {
 					array_push($this->attachNum, (int) $num);
+				}
+			}
+		}
+
+		if (!empty($data['selectedAttachNum']) && is_array($data['selectedAttachNum'])) {
+			/*
+			 * Restricts an 'AllAsZip' request to the named attachments. Only numeric attachment
+			 * numbers are accepted: an unsaved attachment of a draft is identified by a temporary
+			 * name rather than a number and cannot be part of such a selection.
+			 */
+			foreach ($data['selectedAttachNum'] as $attachNum) {
+				$num = sanitizeValue($attachNum, false, NUMERIC_REGEX);
+
+				if ($num !== false) {
+					array_push($this->selectedAttachNum, (int) $num);
 				}
 			}
 		}
@@ -534,6 +557,13 @@ class DownloadAttachment extends DownloadBase {
 		$attachments = mapi_table_queryallrows($attachmentTable, [PR_ATTACH_NUM, PR_ATTACH_METHOD]);
 
 		foreach ($attachments as $attachmentRow) {
+			// A selection narrows the archive to the attachments it names; without one
+			// every attachment of the message goes in, as it always has.
+			if (!empty($this->selectedAttachNum) &&
+				!in_array((int) $attachmentRow[PR_ATTACH_NUM], $this->selectedAttachNum, true)) {
+				continue;
+			}
+
 			if ($attachmentRow[PR_ATTACH_METHOD] !== ATTACH_EMBEDDED_MSG) {
 				$attachment = mapi_message_openattach($this->message, $attachmentRow[PR_ATTACH_NUM]);
 
@@ -560,9 +590,13 @@ class DownloadAttachment extends DownloadBase {
 
 		// Go for adding unsaved attachments in ZIP, if any.
 		// This situation arise while user upload attachments in draft.
-		$attachmentFiles = $attachment_state->getAttachmentFiles($this->dialogAttachments);
-		if ($attachmentFiles) {
-			$this->addUnsavedAttachmentsToZipArchive($attachment_state, $zip);
+		// A selection names attachments by number, which an unsaved one does not have,
+		// so adding them would put files into the archive that were never selected.
+		if (empty($this->selectedAttachNum)) {
+			$attachmentFiles = $attachment_state->getAttachmentFiles($this->dialogAttachments);
+			if ($attachmentFiles) {
+				$this->addUnsavedAttachmentsToZipArchive($attachment_state, $zip);
+			}
 		}
 	}
 


### PR DESCRIPTION
Selecting more than one attachment was not possible: the attachment box is a single-selection `Ext.DataView`, so every gesture acted on the one item under the cursor. Ctrl- and shift-click now build a selection, and three things can be done with it.

**Dragging a selection into another grommunio Web tab or window** carries all of it. The custom drag type is read as either one payload or an array of them, and has been since it was written, so only the sending side changed.

**Dragging a selection to the file manager or the desktop** hands over a single ZIP of exactly that selection, because one file is all the operating system will take.

**"Save selection to folder"** in the attachment context menu writes the selected attachments into a folder the user picks, as loose files, for when an archive is not what is wanted. It appears only for a selection of several, so the single-attachment case is untouched.

## Why a selection reaches the desktop as an archive

A drag can hand the operating system at most one file. Chromium's `DropData` holds a single optional `DownloadUrlMetadata` (`content/public/common/drop_data.h`), while its multi-valued `filenames` vector is documented as the direction *into* the webview — which is why dropping many files into the browser works and the reverse does not. The only other outbound path turns a JavaScript `File` into a `BinaryDataItem` behind the `DragAndDropJSFileObjects` runtime feature and a magic-byte image check, so it is no help for attachments.

Since the operating system takes exactly one file, it gets the one file that holds all of them. Writing only the attachment under the cursor would put a single file on the desktop and look like it had put them all there, and refusing the drop outright leaves the gesture doing nothing at all.

The archive is the existing `AllAsZip` endpoint, narrowed. It has always zipped every attachment of the message and ignored the attachment numbers it was handed; a new `selectedAttachNum[]` restricts it to exactly those, and without the parameter nothing about it changes. The cooperating web target is unaffected and still receives the attachments themselves rather than an archive.

## Behaviour

- A click carrying ctrl or shift selects and does not open the attachment. A plain click opens it, as before.
- A drag or a right-click starting inside a selection covers the whole selection; one starting elsewhere covers only that item and leaves the selection alone. These are Explorer's semantics, so no checkbox column is needed.
- Embedded messages drop out of a selection rather than blocking it, since they are backed by no single downloadable file.
- The payloads of a selection are handed over together or not at all. They cannot be fetched from inside `dragstart`, which is synchronous, and passing on the subset that happens to be cached would drop the rest without telling anyone; a missing one starts its download instead, so the next drag carries everything. Selecting attachments starts those downloads, and a prefetch beyond `maxConcurrentPrefetch` is now queued rather than dropped — without that, a selection larger than the concurrency limit could never become complete.
- An unsaved attachment of a draft cannot be part of a narrowed archive: it is identified by a temporary name rather than an attachment number. The client then offers no archive at all rather than one quietly missing a file, and the server leaves unsaved attachments out of a narrowed archive rather than adding files that were never selected.
- The suggested file name mirrors the `Content-Disposition` the server sends, so the file that lands on the desktop is named the same whichever way it was fetched.
- Saving to a folder steps over a name the folder already holds rather than writing through it, since `getFileHandle` with `create` truncates the user's file without asking. Sender-controlled names are reduced to a basename a file system will accept, and a write that fails part way removes its own entry, because an empty file carrying an attachment's name reads as a saved attachment. A complete save is silent; anything that did not make it is named.

`showDirectoryPicker()` is Chromium-only and needs a secure context, so the menu item is hidden elsewhere rather than failing when it is used — the same availability the existing drag-out already has.