### PR TITLE
favorites: a failed settings read must not delete every favorite

### DIFF
--- a/server/includes/core/class.operations.php
+++ b/server/includes/core/class.operations.php
@@ -716,6 +716,20 @@ class Operations {
 	 * @param array  $storeData               the store data which use to create restriction
 	 */
 	public function setDefaultFavoritesFolder($commonViewFolderEntryid, $store, $storeData) {
+		// The branch below deletes every favourite and every saved search of this
+		// user, so it may only run when the flag it tests was really read from
+		// the store. If loading the settings failed, get() answers with its
+		// default for every path, an absent flag is indistinguishable from a
+		// mailbox that has never been initialised, and the user's favourites are
+		// deleted because of a failed read.
+		if (!$GLOBALS["settings"]->isLoaded()) {
+			$msg = "Operations:setDefaultFavoritesFolder() skipped: the settings of this store could not be loaded, so whether the default favourites are still wanted is unknown.";
+			error_log($msg);
+			Log::Write(LOGLEVEL_ERROR, $msg);
+
+			return;
+		}
+
 		if ($GLOBALS["settings"]->get("zarafa/v1/contexts/hierarchy/show_default_favorites") !== false) {
 			$commonViewFolder = mapi_msgstore_openentry($store, $commonViewFolderEntryid);
 

--- a/server/includes/core/class.operations.php
+++ b/server/includes/core/class.operations.php
@@ -716,12 +716,9 @@ class Operations {
 	 * @param array  $storeData               the store data which use to create restriction
 	 */
 	public function setDefaultFavoritesFolder($commonViewFolderEntryid, $store, $storeData) {
-		// The branch below deletes every favourite and every saved search of this
-		// user, so it may only run when the flag it tests was really read from
-		// the store. If loading the settings failed, get() answers with its
-		// default for every path, an absent flag is indistinguishable from a
-		// mailbox that has never been initialised, and the user's favourites are
-		// deleted because of a failed read.
+		// An unloaded settings object answers get() with defaults, so an absent
+		// flag would read as "never initialised" and the branch below would
+		// delete every favorite and saved search this user has.
 		if (!$GLOBALS["settings"]->isLoaded()) {
 			$msg = "Operations:setDefaultFavoritesFolder() skipped: the settings of this store could not be loaded, so whether the default favourites are still wanted is unknown.";
 			error_log($msg);

--- a/server/includes/core/class.settings.php
+++ b/server/includes/core/class.settings.php
@@ -102,7 +102,25 @@ class Settings {
 		}
 		catch (SettingsException $e) {
 			$e->setHandled();
+
+			// $this->init stays false, so from here get() answers with its
+			// default for every path.
+			Log::Write(LOGLEVEL_ERROR, "Settings::Init(): the settings of this store could not be loaded, continuing with defaults for every setting: " . $e->getMessage());
 		}
+	}
+
+	/**
+	 * False means the load threw and was handled, so {@link #get} answers with
+	 * its default for every path rather than with a stored value.
+	 *
+	 * @return bool true when the settings came from the store
+	 */
+	public function isLoaded() {
+		if (!$this->init) {
+			$this->Init();
+		}
+
+		return $this->init;
 	}
 
 	/**

--- a/server/includes/util.php
+++ b/server/includes/util.php
@@ -597,9 +597,30 @@ function streamProperty($mapiobj, $proptag) {
 	$stat = mapi_stream_stat($stream);
 	mapi_stream_seek($stream, 0, STREAM_SEEK_SET);
 
+	// Read until the whole property is assembled rather than assuming every read
+	// returns a full block. Advancing by BLOCK_SIZE regardless of what came back
+	// silently returns a short value, and the callers parse what they are given:
+	// a truncated PR_EC_WEBACCESS_SETTINGS_JSON is what makes the settings of a
+	// store fail to load.
 	$datastring = '';
-	for ($i = 0; $i < $stat['cb']; $i += BLOCK_SIZE) {
-		$datastring .= mapi_stream_read($stream, BLOCK_SIZE);
+	while (strlen($datastring) < $stat['cb']) {
+		$chunk = mapi_stream_read($stream, BLOCK_SIZE);
+		if ($chunk === false || $chunk === '') {
+			break;
+		}
+
+		$datastring .= $chunk;
+	}
+
+	// Still short: the value is incomplete and the caller cannot see that, so
+	// leave a trace rather than handing back something that merely looks valid.
+	if (strlen($datastring) < $stat['cb']) {
+		error_log(sprintf(
+			"streamProperty(): property 0x%08X is truncated, read %d of %d bytes",
+			$proptag,
+			strlen($datastring),
+			$stat['cb']
+		));
 	}
 
 	return $datastring;

--- a/server/includes/util.php
+++ b/server/includes/util.php
@@ -597,11 +597,8 @@ function streamProperty($mapiobj, $proptag) {
 	$stat = mapi_stream_stat($stream);
 	mapi_stream_seek($stream, 0, STREAM_SEEK_SET);
 
-	// Read until the whole property is assembled rather than assuming every read
-	// returns a full block. Advancing by BLOCK_SIZE regardless of what came back
-	// silently returns a short value, and the callers parse what they are given:
-	// a truncated PR_EC_WEBACCESS_SETTINGS_JSON is what makes the settings of a
-	// store fail to load.
+	// A read may return less than a full block, so count bytes rather than
+	// iterations: advancing by BLOCK_SIZE regardless returns a short value.
 	$datastring = '';
 	while (strlen($datastring) < $stat['cb']) {
 		$chunk = mapi_stream_read($stream, BLOCK_SIZE);
@@ -612,8 +609,7 @@ function streamProperty($mapiobj, $proptag) {
 		$datastring .= $chunk;
 	}
 
-	// Still short: the value is incomplete and the caller cannot see that, so
-	// leave a trace rather than handing back something that merely looks valid.
+	// The caller cannot tell a short value from a complete one, so say so here.
 	if (strlen($datastring) < $stat['cb']) {
 		error_log(sprintf(
 			"streamProperty(): property 0x%08X is truncated, read %d of %d bytes",


### PR DESCRIPTION
A user can lose every favorite and every saved search because their settings failed to load, and nothing about the failure is favorites-related.

`Operations::setDefaultFavoritesFolder()` deletes every `IPM.Microsoft.WunderBar.Link` and `IPM.Microsoft.WunderBar.SFInfo` except the Inbox and Sent Items links, and every folder in `FINDER_ROOT`, then creates the two defaults. That is right for a mailbox that has never been initialised, and it decides from one setting:

```php
if ($GLOBALS["settings"]->get("zarafa/v1/contexts/hierarchy/show_default_favorites") !== false) {
```

`Settings::get()` returns `null` for a path it cannot find, and `null !== false` is `true`. The branch therefore runs in two situations, not one: for a new mailbox, and whenever the settings could not be read **at all**.

## How the settings come to be unreadable

`Settings::Init()` catches `SettingsException`, marks it handled and carries on with an empty settings array. Carrying on is reasonable — a store whose settings are unreadable should still open — but from that point `get()` answers with its default for every path, so an absent flag is indistinguishable from a deliberate one.

`retrieveSettings()` throws exactly that exception when `PR_EC_WEBACCESS_SETTINGS_JSON` is present but does not decode into something with a `settings` key. And `streamProperty()`, which reads it, advanced its offset by `BLOCK_SIZE` per iteration regardless of how many bytes came back and never looked at the result of a single `mapi_stream_read()` — so a short read yielded a truncated value that no caller could distinguish from a complete one.

The last line of the destructive branch then writes `show_default_favorites` back as `false`, so the next load looks normal and the loss reads to the user as a one-off.

## What this changes

- `setDefaultFavoritesFolder()` returns early unless the settings really came from the store. A missing value may mean *never initialised*, but it may equally mean *unknown*, and deleting user data must not be what happens when the answer is unknown.
- `Settings` logs the load failure and exposes it as `isLoaded()`, so a caller whose behaviour depends on that difference can ask instead of inferring it from a `null`.
- `streamProperty()` reads until the property is assembled, stops on a read that yields nothing, and logs when the result is still short. This is the part that reduces how often the state arises at all, and it applies to all ten callers rather than to settings alone.

Behaviour for a genuinely new mailbox is unchanged: no `PR_EC_WEBACCESS_SETTINGS_JSON` is not an error, `retrieveSettings()` does not throw for it, so the settings count as loaded and the defaults are created as before.

## Verified

Measured against a running server, on the same stack, by planting a settings blob that decodes but carries no `settings` key - the exact condition `retrieveSettings()` throws on - with five favorites in the mailbox beforehand (the two defaults plus three folders).

| Arm | Favorites afterwards |
|---|---|
| This branch | **5** — `Posteingang`, `Gesendete Elemente`, `Project A`, `Project B`, `test12` |
| Same build, guard removed | **2** — `Posteingang`, `Gesendete Elemente` |