### PR TITLE
previewer: open an attachment preview in a tab or a browser window

### DIFF
--- a/client/zarafa/common/Actions.js
+++ b/client/zarafa/common/Actions.js
@@ -1503,12 +1503,27 @@ Zarafa.common.Actions = {
 	},
 
 	/**
-	 * The {@link Zarafa.core.data.UIFactory} layer a preview opens in, from
-	 * zarafa/v1/main/file_previewer/target.
+	 * The {@link Zarafa.core.data.UIFactory} layers a preview can open in, in the
+	 * order they are offered. A browser window needs
+	 * {@link Zarafa#supportsPopOut pop-out}, so it is absent where that is missing.
 	 *
-	 * A browser window is only offered where {@link Zarafa#supportsPopOut pop-out}
-	 * works, so a stored choice of it is answered with the dialog elsewhere rather
-	 * than with a layer that cannot open.
+	 * @return {String[]} layer types
+	 */
+	getFilePreviewerTargets: function ()
+	{
+		var targets = ['dialogs', 'tabs'];
+
+		if (Zarafa.supportsPopOut()) {
+			targets.push('separateWindows');
+		}
+
+		return targets;
+	},
+
+	/**
+	 * The layer a preview opens in, from zarafa/v1/main/file_previewer/target.
+	 * An unavailable or unknown choice is answered with the dialog rather than
+	 * with a layer that cannot open.
 	 *
 	 * @return {String} a layer type: 'dialogs', 'tabs' or 'separateWindows'
 	 */
@@ -1516,11 +1531,7 @@ Zarafa.common.Actions = {
 	{
 		var target = container.getSettingsModel().get('zarafa/v1/main/file_previewer/target');
 
-		if (Ext.isEmpty(target) || (target === 'separateWindows' && !Zarafa.supportsPopOut())) {
-			return 'dialogs';
-		}
-
-		return target;
+		return Zarafa.common.Actions.getFilePreviewerTargets().indexOf(target) === -1 ? 'dialogs' : target;
 	},
 
 	/**

--- a/client/zarafa/common/Actions.js
+++ b/client/zarafa/common/Actions.js
@@ -1354,17 +1354,25 @@ Zarafa.common.Actions = {
 	openAttachmentRecord: function(record, config)
 	{
 		var modal = false;
+		var layerType;
 		if(record.isEmbeddedMessage()) {
 			// if we are going to open embedded message then we need to first convert it into mail record
 			record = record.convertToIPMRecord();
-		} else {
-			modal = Zarafa.common.Actions.isSupportedDocument(record.get("name"));
+		} else if (Zarafa.common.Actions.isSupportedDocument(record.get("name"))) {
+			// 'modal' is accepted by the dialog layer alone, and passing it forces
+			// that layer whatever the setting asks for.
+			layerType = Zarafa.common.Actions.getFilePreviewerTarget();
+			modal = layerType === 'dialogs';
 		}
 
 		config = Ext.applyIf(config||{}, {
 			modal: modal,
 			autoResize: true
 		});
+
+		if (!modal && !Ext.isEmpty(layerType)) {
+			config = Ext.applyIf(config, {layerType: layerType});
+		}
 
 		if(record) {
 			Zarafa.core.data.UIFactory.openViewRecord(record, config);
@@ -1492,6 +1500,27 @@ Zarafa.common.Actions = {
 		}
 		// First of all check if filepreviewer plugin settings available else check main settings.
 		return container.getSettingsModel().getOneOf('zarafa/v1/plugins/filepreviewer/enable', 'zarafa/v1/main/file_previewer/enable');
+	},
+
+	/**
+	 * The {@link Zarafa.core.data.UIFactory} layer a preview opens in, from
+	 * zarafa/v1/main/file_previewer/target.
+	 *
+	 * A browser window is only offered where {@link Zarafa#supportsPopOut pop-out}
+	 * works, so a stored choice of it is answered with the dialog elsewhere rather
+	 * than with a layer that cannot open.
+	 *
+	 * @return {String} a layer type: 'dialogs', 'tabs' or 'separateWindows'
+	 */
+	getFilePreviewerTarget: function ()
+	{
+		var target = container.getSettingsModel().get('zarafa/v1/main/file_previewer/target');
+
+		if (Ext.isEmpty(target) || (target === 'separateWindows' && !Zarafa.supportsPopOut())) {
+			return 'dialogs';
+		}
+
+		return target;
 	},
 
 	/**

--- a/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
+++ b/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
@@ -185,14 +185,23 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 
 	/**
 	 * Event handler which is called when the user selects the 'Preview'
-	 * item in the context menu. This will open the item in a new dialog.
+	 * item in the context menu. This will open the item in the layer the user
+	 * configured: a dialog, a grommunio Web tab or a browser window.
 	 * @private
 	 */
 	onPreviewItem: function()
 	{
 		//should already have a component that has won the bid
 		//invoke that component to open the preview
-		Zarafa.core.data.UIFactory.openViewRecord(this.records, {modal: true, autoResize: true});
+		var layerType = Zarafa.common.Actions.getFilePreviewerTarget();
+		var config = {modal: layerType === 'dialogs', autoResize: true};
+
+		// 'modal' would force the dialog layer, so it and layerType are exclusive.
+		if (!config.modal) {
+			config.layerType = layerType;
+		}
+
+		Zarafa.core.data.UIFactory.openViewRecord(this.records, config);
 	},
 
 	/**

--- a/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
+++ b/client/zarafa/common/attachment/ui/AttachmentContextMenu.js
@@ -59,6 +59,22 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 			handler: this.onPreviewItem,
 			beforeShow: this.onPreviewBeforeShow
 		}, {
+			// The layers the setting did not pick. Their text is set in
+			// beforeShow, since which two they are depends on the setting.
+			text: _('Preview in a dialog'),
+			iconCls: 'icon_attachment_preview',
+			previewSlot: 0,
+			scope: this,
+			handler: this.onPreviewInTarget,
+			beforeShow: this.onPreviewInTargetBeforeShow
+		}, {
+			text: _('Preview in a dialog'),
+			iconCls: 'icon_attachment_preview',
+			previewSlot: 1,
+			scope: this,
+			handler: this.onPreviewInTarget,
+			beforeShow: this.onPreviewInTargetBeforeShow
+		}, {
 			text: _('Download'),
 			iconCls: 'icon_download',
 			scope: this,
@@ -193,15 +209,77 @@ Zarafa.common.attachment.ui.AttachmentContextMenu = Ext.extend(Zarafa.core.ui.me
 	{
 		//should already have a component that has won the bid
 		//invoke that component to open the preview
-		var layerType = Zarafa.common.Actions.getFilePreviewerTarget();
-		var config = {modal: layerType === 'dialogs', autoResize: true};
+		this.openPreviewIn(Zarafa.common.Actions.getFilePreviewerTarget());
+	},
 
+	/**
+	 * Event handler for the two items which preview in a layer other than the
+	 * configured one. The layer was put on the item by
+	 * {@link #onPreviewInTargetBeforeShow}.
+	 * @param {Zarafa.core.ui.menu.ConditionalItem} item The clicked item
+	 * @private
+	 */
+	onPreviewInTarget: function(item)
+	{
+		this.openPreviewIn(item.previewTarget);
+	},
+
+	/**
+	 * Opens the preview in the given {@link Zarafa.core.data.UIFactory} layer.
+	 * @param {String} layerType 'dialogs', 'tabs' or 'separateWindows'
+	 * @private
+	 */
+	openPreviewIn: function(layerType)
+	{
 		// 'modal' would force the dialog layer, so it and layerType are exclusive.
+		var config = {modal: layerType === 'dialogs', autoResize: true};
 		if (!config.modal) {
 			config.layerType = layerType;
 		}
 
 		Zarafa.core.data.UIFactory.openViewRecord(this.records, config);
+	},
+
+	/**
+	 * Labels one of the two alternative preview items and hides it when there is
+	 * no layer left for its slot, which is the case for the second one where
+	 * pop-out is unavailable. Visibility otherwise follows the 'Preview' item.
+	 * @param {Zarafa.core.ui.menu.ConditionalItem} item context menu item
+	 * @param {Zarafa.core.data.IPMAttachmentRecord} record attachment record on which context menu is shown
+	 */
+	onPreviewInTargetBeforeShow: function(item, record)
+	{
+		var configured = Zarafa.common.Actions.getFilePreviewerTarget();
+		var alternatives = Zarafa.common.Actions.getFilePreviewerTargets().filter(function(target) {
+			return target !== configured;
+		});
+
+		item.previewTarget = alternatives[item.previewSlot];
+		if (!item.previewTarget) {
+			item.setVisible(false);
+
+			return;
+		}
+
+		item.setText(this.getPreviewTargetText(item.previewTarget));
+		this.onPreviewBeforeShow(item, record);
+	},
+
+	/**
+	 * @param {String} target 'dialogs', 'tabs' or 'separateWindows'
+	 * @return {String} the menu text offering a preview in that layer
+	 * @private
+	 */
+	getPreviewTargetText: function(target)
+	{
+		switch (target) {
+			case 'tabs':
+				return _('Preview in a grommunio Web tab');
+			case 'separateWindows':
+				return _('Preview in a browser window');
+			default:
+				return _('Preview in a dialog');
+		}
 	},
 
 	/**

--- a/client/zarafa/settings/data/SettingsDefaultValues.js
+++ b/client/zarafa/settings/data/SettingsDefaultValues.js
@@ -501,7 +501,14 @@ Zarafa.settings.data.SettingsDefaultValue = function(){
 								 * zarafa/v1/main/file_previewer/odf_zoom
 								 * Default zoom mode for ODF documents. (default: auto) [Allowed: "auto", "page-actual", "page-width"]
 								 */
-								'odf_zoom': 'page-width'
+								'odf_zoom': 'page-width',
+
+								/**
+								 * zarafa/v1/main/file_previewer/target
+								 * Where a preview opens. (default: dialogs) [Allowed: "dialogs", "tabs", "separateWindows"]
+								 * The values are layer types of Zarafa.core.data.UIFactory.
+								 */
+								'target': 'dialogs'
 							},
 
 							/**

--- a/client/zarafa/settings/ui/SettingsFilePreviewerWidget.js
+++ b/client/zarafa/settings/ui/SettingsFilePreviewerWidget.js
@@ -65,27 +65,20 @@ Zarafa.settings.ui.SettingsFilePreviewerWidget = Ext.extend(Zarafa.settings.ui.S
 	        }
 	    ]));
 
-	    var targets = [{
-	        xtype: 'radio',
-	        name: 'previewTarget',
-	        inputValue: 'dialogs',
-	        boxLabel: _('Dialog')
-	    },{
-	        xtype: 'radio',
-	        name: 'previewTarget',
-	        inputValue: 'tabs',
-	        boxLabel: _('grommunio Web tab')
-	    }];
+	    var labels = {
+	        'dialogs': _('Dialog'),
+	        'tabs': _('grommunio Web tab'),
+	        'separateWindows': _('Browser window')
+	    };
 
-	    // A browser window is offered only where pop-out works, as for mail.
-	    if (Zarafa.supportsPopOut()) {
-	        targets.push({
+	    var targets = Zarafa.common.Actions.getFilePreviewerTargets().map(function(target) {
+	        return {
 	            xtype: 'radio',
 	            name: 'previewTarget',
-	            inputValue: 'separateWindows',
-	            boxLabel: _('Browser window')
-	        });
-	    }
+	            inputValue: target,
+	            boxLabel: labels[target]
+	        };
+	    });
 
 	    items.push({
 	        xtype: 'displayfield',

--- a/client/zarafa/settings/ui/SettingsFilePreviewerWidget.js
+++ b/client/zarafa/settings/ui/SettingsFilePreviewerWidget.js
@@ -65,6 +65,45 @@ Zarafa.settings.ui.SettingsFilePreviewerWidget = Ext.extend(Zarafa.settings.ui.S
 	        }
 	    ]));
 
+	    var targets = [{
+	        xtype: 'radio',
+	        name: 'previewTarget',
+	        inputValue: 'dialogs',
+	        boxLabel: _('Dialog')
+	    },{
+	        xtype: 'radio',
+	        name: 'previewTarget',
+	        inputValue: 'tabs',
+	        boxLabel: _('grommunio Web tab')
+	    }];
+
+	    // A browser window is offered only where pop-out works, as for mail.
+	    if (Zarafa.supportsPopOut()) {
+	        targets.push({
+	            xtype: 'radio',
+	            name: 'previewTarget',
+	            inputValue: 'separateWindows',
+	            boxLabel: _('Browser window')
+	        });
+	    }
+
+	    items.push({
+	        xtype: 'displayfield',
+	        hideLabel: true,
+	        value: _('Open a preview in a') + ':'
+	    },{
+	        xtype: 'radiogroup',
+	        name: 'zarafa/v1/main/file_previewer/target',
+	        ref: 'previewTarget',
+	        columns: 1,
+	        hideLabel: true,
+	        items: targets,
+	        listeners: {
+	            change: this.onRadioChange,
+	            scope: this
+	        }
+	    });
+
 	    Ext.applyIf(config, {
 	        xtype: 'zarafa.settingsdisplaywidget',
 	        title: _('File previewing'),
@@ -120,6 +159,7 @@ Zarafa.settings.ui.SettingsFilePreviewerWidget = Ext.extend(Zarafa.settings.ui.S
 		this.pdfZoom.setDisabled(!checked);
 		this.odfZoom.disableLabel(!checked);
 		this.pdfZoom.disableLabel(!checked);
+		this.previewTarget.setDisabled(!checked);
 	},
 
 	/**
@@ -148,6 +188,10 @@ Zarafa.settings.ui.SettingsFilePreviewerWidget = Ext.extend(Zarafa.settings.ui.S
 		this.odfZoom.setValue(settingsModel.get(this.odfZoom.name));
 		this.odfZoom.setDisabled(!enableFilePreviewer);
 		this.odfZoom.disableLabel(!enableFilePreviewer);
+
+		// Where a preview opens
+		this.previewTarget.setValue(settingsModel.get(this.previewTarget.name));
+		this.previewTarget.setDisabled(!enableFilePreviewer);
 	},
 
 	/**
@@ -170,6 +214,12 @@ Zarafa.settings.ui.SettingsFilePreviewerWidget = Ext.extend(Zarafa.settings.ui.S
 
 		// Set the value for ODFzoom
 		settingsModel.set(this.odfZoom.name, this.odfZoom.getValue());
+
+		// A stored value whose radio is not offered leaves the group unset.
+		var target = this.previewTarget.getValue();
+		if (target) {
+			settingsModel.set(this.previewTarget.name, target.inputValue);
+		}
 	},
 
 	/**
@@ -203,6 +253,19 @@ Zarafa.settings.ui.SettingsFilePreviewerWidget = Ext.extend(Zarafa.settings.ui.S
 			if (this.model.get(field.name) !== field.getValue()) {
 				this.model.set(field.name, field.getValue());
 			}
+		}
+	},
+
+	/**
+	 * Event handler which is fired when a radio in the {@link Ext.form.RadioGroup group}
+	 * has been selected.
+	 * @param {Ext.form.RadioGroup} group The group which fired the event
+	 * @param {Ext.form.Radio} radio The selected radio
+	 */
+	onRadioChange : function(group, radio)
+	{
+		if (this.model && radio && this.model.get(group.name) !== radio.inputValue) {
+			this.model.set(group.name, radio.inputValue);
 		}
 	}
 


### PR DESCRIPTION
An attachment preview could only appear in a modal dialog. It covers the mailbox while it is open and cannot be kept beside the message it belongs to, so reading a document and its mail together means closing and reopening the preview.

Mail already offers this choice through `zarafa/v1/main/base_content_layer`. Previews now have the same one under **`zarafa/v1/main/file_previewer/target`**, as a third control in the existing *File previewing* settings widget: **Dialog**, **grommunio Web tab**, **Browser window**.

The default is `dialogs`, so nothing changes for a user who does not touch the setting.

## How it works

The stored values are the layer types of `Zarafa.core.data.UIFactory` — `dialogs`, `tabs`, `separateWindows` — so the setting is handed straight to `layerType` and no mapping is needed.

`modal` and the setting are exclusive, which is why both open sites pick one or the other rather than passing both. `getPreferredLayer()` searches upwards from the first layer for one that accepts `modal`, which lands on the dialog whatever else was asked for, and it only consults the configured layer while the index is still at the first. So `modal` is passed for the dialog, and `layerType` for the other two.

A browser window is offered only where `Zarafa.supportsPopOut()` holds, as in the mail settings. A value stored while it did hold is answered with the dialog elsewhere, rather than with a layer that cannot open — the radio for it is then absent, so the group is simply unset and the fallback in `getFilePreviewerTarget()` decides.

The two places a preview opens are covered: clicking an attachment, and *Preview* in its context menu. Non-previewable attachments are untouched, since they never reach the previewer.

## The other two layers are one click away

The setting decides where *Preview* opens, so reaching either of the other layers would otherwise mean a trip through the settings. The context menu therefore also offers the two the setting did not pick, which lets a single preview go to a tab or a window without changing the preference.

Which two they are depends on the setting, so the items are labelled in `beforeShow`. Where pop-out is unavailable only one alternative remains and the second item hides itself. Their availability is the `Preview` item's own `beforeShow`, so all three appear, disable and disappear together.

`Actions.getFilePreviewerTargets()` holds the list of layers and the settings widget builds its radios from it, so the condition for offering a browser window lives in one place rather than three.

The radio labels for a tab and a window reuse the strings the mail settings already ship. New to the catalogs are *Dialog*, *Open a preview in a*, and the three menu entries.

## Verified

| Setting | Layer chosen | What happened |
|---|---|---|
| `dialogs` | `dialogs`, `modal: true` | a window on screen, unchanged from before |
| `tabs` | `tabs`, `modal: false` | a closable tab appeared, no browser window |
| `separateWindows` | `separateWindows` | a browser window opened at `index.php?load=separate_window` |

