### PR TITLE
attachment: keep an inline image when the mail is forwarded

### DIFF
--- a/client/zarafa/core/HTMLParser.js
+++ b/client/zarafa/core/HTMLParser.js
@@ -1052,8 +1052,18 @@ Zarafa.core.HTMLParser = (function() {
 
 			var urlToCid = function(match, srcStart, imgCid, srcEnd, offset, str) {
 				if(imgCid) {
+					// The cid was percent-encoded into the download url, so decode it
+					// again: cid:local%40domain matches no attachment.
+					var cid = imgCid;
+
+					try {
+						cid = decodeURIComponent(imgCid);
+					} catch (e) {
+						// not valid percent-encoding, keep it as it came in
+					}
+
 					// return img src with just cid: tag
-					return srcStart + 'cid:' + imgCid + srcEnd;
+					return srcStart + 'cid:' + cid + srcEnd;
 				}
 
 				// return match as it is but in a real world this is not going to happen

--- a/client/zarafa/core/HTMLParser.js
+++ b/client/zarafa/core/HTMLParser.js
@@ -26,6 +26,9 @@ Zarafa.core.HTMLParser = (function() {
 	// regular expression to convert url for inline images to outlook style url
 	var urlToCidRe = /(src\s*=\s*[\"\']?)\S*attachCid=([^ &\"\']*)[^ \"\']*([\"\']?)/igm;
 
+	// regular expression to strip the editor's own copy of an image src
+	var dataMceSrcRe = /\s+data-mce-src\s*=\s*(?:\"[^\"]*\"|\'[^\']*\'|[^\s>]*)/igm;
+
 	var cssUrlRe = /url\(\s*(['"]?)([^'")]+)\1\s*\)/igm;
 	var cssImportRe = /@import\s+(?:url\(\s*)?(['"]?)([^'")\s;]+)\1\s*\)?/igm;
 	var hrefResourceTags = {
@@ -1025,6 +1028,11 @@ Zarafa.core.HTMLParser = (function() {
 				// return match as it is but in a real world this is not going to happen
 				return match;
 			};
+
+			// A stored data-mce-src overrides src when the editor serializes the body
+			// again, so the image would go back out as a bare <img>. Older grommunio
+			// Web wrote an empty one next to every inline image it created.
+			body = body.replace(dataMceSrcRe, '');
 
 			// replace cid: with our own url to get inline attachment
 			return body.replace(cidToUrlRe, cidToUrl);

--- a/server/includes/core/class.operations.php
+++ b/server/includes/core/class.operations.php
@@ -5295,8 +5295,9 @@ class Operations {
 
 					$uniqueId = uniqid();
 					$image->setAttribute('src', 'cid:' . $uniqueId);
-					// TinyMCE adds an extra inline image for some reason, remove it.
-					$image->setAttribute('data-mce-src', '');
+					// Never stored: TinyMCE serializes src *from* data-mce-src on any
+					// later edit, so an empty stored value drops the src.
+					$image->removeAttribute('data-mce-src');
 
 					array_push($imageIDs, $uniqueId);
 

--- a/server/includes/core/class.operations.php
+++ b/server/includes/core/class.operations.php
@@ -3980,17 +3980,6 @@ class Operations {
 
 			$plainText = $this->isPlainText($message);
 
-			$properties = $GLOBALS['properties']->getMailProperties();
-			$blockStatus = mapi_getprops($copyFromMessage, [PR_BLOCK_STATUS]);
-			$blockStatus = Conversion::mapMAPI2XML($properties, $blockStatus);
-			$isSafeSender = false;
-
-			// Here if message is HTML and block status is empty then and then call isSafeSender function
-			// to check that sender or sender's domain of original message was part of safe sender list.
-			if (!$plainText && empty($blockStatus)) {
-				$isSafeSender = $this->isSafeSender($copyFromMessage);
-			}
-
 			$body = false;
 			foreach ($existingAttachments as $props) {
 				// check if this attachment is "deleted"
@@ -4041,20 +4030,8 @@ class Operations {
 					}
 				}
 
-				/*
-				 * if message is reply/reply all or forward and format of message is HTML but
-				 * - inline attachments are not downloaded from external source
-				 * - sender of original message is not safe sender
-				 * - domain of sender is not part of safe sender list
-				 * then ignore inline attachments from original message.
-				 *
-				 * NOTE : blockStatus is only generated when user has download inline image from external source.
-				 * it should remains empty if user add the sender in to safe sender list.
-				 */
-				if (!$plainText && $isInlineAttachment && empty($blockStatus) && !$isSafeSender) {
-					continue;
-				}
-
+				// No PR_BLOCK_STATUS or safe-sender check here: external content owns no
+				// attachment, and these bytes are already in the message being copied.
 				$new = mapi_message_createattach($message);
 
 				try {


### PR DESCRIPTION
## What happens

A mail with a pasted screenshot arrives correctly. Forward that mail and the image is gone: the recipient gets an `<img>` with no `src` and no attachment behind it, which renders as an empty box. A reply that keeps the original body loses it the same way.

## Why

Three separate causes, all on the path a stored body takes into the editor and back.

**The editor's own copy of the src is stored in the message.** `Operations::convertInlineImage()` turns a pasted `data:` image into a `cid:` attachment and then sets `data-mce-src=""` on the same element. TinyMCE serializes `src` *from* `data-mce-src`, so the next time that body is loaded into the editor — forward, reply, edit as new — the empty value wins and the src is dropped before the message is submitted.

**The content id is not decoded on the way back.** `inlineImgOutlookToZarafa()` percent-encodes the content id into the `attachCid` parameter of the download url, and `inlineImgZarafaToOutlook()` wrote it back undecoded. A content id of the usual `local@domain` form therefore returned as `cid:local%40domain`, which matches no attachment. This affects inline images from other mail clients; grommunio Web's own `uniqid()` ids are hex and survive the round trip.

**The inline attachment was then dropped server side.** `copyAttachments()` skipped an inline attachment unless `PR_BLOCK_STATUS` was set or the sender was in the safe senders list. That check cannot apply to what this loop sees: external content is a bare `<img src="http://...">` and owns no attachment at all, while an inline attachment is `ATTACH_BY_VALUE` with a content id whose bytes are already part of the message being copied. The check just above it has also established that the new body still references this content id, so skipping it left the body pointing at an attachment that does not exist.

## The change

One commit per cause: stop storing `data-mce-src` and strip a stored one when a body is prepared for the client, decode the content id in `inlineImgZarafaToOutlook()`, and drop the safe-sender check on inline attachments together with the `PR_BLOCK_STATUS` and `isSafeSender()` lookup in `copyAttachments()` that only fed it.

## Verified

Against a gromox backend, read back from the stored message after forwarding a mail whose body embeds a screenshot:

| case | stored src | inline attachments |
|---|---|---|
| before the change | `<img>`, no src | 0 |
| inline image created by grommunio Web (hex content id) | `cid:6a9e5c48d38e0` | 1 |
| inline image from another client (`local@domain`) | `cid:extshot@example.org` | 1 |
| reply keeping the original body | `cid:6a9e5c48d38e0` | 1 |
| three ordinary attachments, external sender | unchanged | 3 |

The forwarded image renders in the reading pane, and a mail whose inline image an earlier version stored with the empty `data-mce-src` forwards correctly too.

The removed check was introduced with a comment about TinyMCE adding a duplicate inline image; forward, reply and the reading pane each show exactly one image after the change, but a flow that relied on the empty attribute for that would be affected.
