### PR TITLE
calendar: do not draw the day grid before it has a width

### DIFF
--- a/client/zarafa/calendar/ui/html/CalendarDaysView.js
+++ b/client/zarafa/calendar/ui/html/CalendarDaysView.js
@@ -227,11 +227,52 @@ Zarafa.calendar.ui.html.CalendarDaysView = Ext.extend(Zarafa.calendar.ui.Abstrac
 	 * @param {Array} dayPositions The array of {@link Zarafa.calendar.data.DayLayoutPosition LayoutPositions} for the various days.
 	 * @private
 	 */
+	/**
+	 * @cfg {Number} maxDrawRetries How often a draw is retried while its element
+	 * has not been given a width yet.
+	 */
+	maxDrawRetries: 20,
+
+	/**
+	 * Whether a draw may proceed. Drawing at zero width stamps width:0 on the grid
+	 * layers, collapsing every calc(100%/n) column, and no later pass redraws them.
+	 *
+	 * @param {String} fn Name of the draw function which is asking
+	 * @param {Number} width The width measured for that draw
+	 * @param {Array} dayPositions The positions the draw was called with
+	 * @return {Boolean} True when the caller may draw
+	 * @private
+	 */
+	readyToDraw: function(fn, width, dayPositions)
+	{
+		if (!this.drawRetries) {
+			this.drawRetries = {};
+		}
+
+		if (width > 0) {
+			this.drawRetries[fn] = 0;
+
+			return true;
+		}
+
+		if ((this.drawRetries[fn] || 0) < this.maxDrawRetries) {
+			this.drawRetries[fn]++;
+			this[fn].defer(60, this, [dayPositions]);
+		}
+
+		return false;
+	},
+
 	drawHeader: function(dayPositions)
 	{
 		// Resize the header
 		var width = this.header.getWidth();
 		var height = this.header.getHeight();
+
+		if (!this.readyToDraw('drawHeader', width, dayPositions)) {
+			return;
+		}
+
 		this.headerBackgroundLayer.setSize(width, height);
 		this.headerBackgroundLayer.dom.innerHTML = '';
 		this.headerAppointmentLayer.setSize(width, height);
@@ -293,6 +334,11 @@ Zarafa.calendar.ui.html.CalendarDaysView = Ext.extend(Zarafa.calendar.ui.Abstrac
 		//var todayPosition;
 		var width = this.body.getWidth();
 		var height = this.body.getHeight();
+
+		if (!this.readyToDraw('drawBody', width, dayPositions)) {
+			return;
+		}
+
 		this.bodyBackground.setSize(width, height);
 		this.bodyBackground.dom.innerHTML = '';
 		this.bodyAppointment.setSize(width, height);


### PR DESCRIPTION

## What happens

The day view renders with its columns collapsed: day cells come out 0 to 1 pixel wide, appointments become unreadable slivers, and the calendar stays that way for the rest of the session. Resizing the browser window repairs it, because that forces another layout pass.

## Why

`drawHeader()` and `drawBody()` size the grid layers from the element they draw into:

```js
var width = this.body.getWidth();
var height = this.body.getHeight();
this.bodyBackground.setSize(width, height);
```

The tracks of those grids are expressed relative to that width — `grid-template-columns` is built as `calc(100%/<days>)` per column. When a draw runs before the element has been given a width, `setSize(0, height)` stamps `width: 0px` on the layer and every track resolves to `0px`. Nothing schedules another draw, so the collapse is permanent until something else triggers a layout.

Measured on an affected session, with two calendars open in the day view:

| element | width | grid-template-columns |
|---|---|---|
| `k-html-body-background` | `0` (`style="width: 0px"`) | `0px 0px 0px 0px 0px` |
| `k-html-body-appointment` | `0` | `20% 20% 20% 20% 20%`, unresolved |
| `k-html-header-background` | `0` (`style="width: 0px"`) | `0px 0px 0px 0px 0px` |
| parent `zarafa-calendar` container | `1542` | — |

The container had its full width throughout, and the measured height came through correctly at 1152 — only the width was missing at draw time. The day cells under those layers measured 0 to 1 pixel wide by 48 high.

## The change

Both draws now ask `readyToDraw()` before touching the layers. With a width they proceed as before; with a width of zero they return and re-run once the element has been sized, bounded by `maxDrawRetries` so a calendar that never receives a width cannot retry forever.

## Verified

Against a live client showing the collapsed day view, patched in place, since the collapse depends on the layout timing of that session:

| case | result |
|---|---|
| collapsed day view, two calendars, before | cells 0-1px, layers `width: 0px` |
| same view after the guard | columns render at full width, appointments legible |
| draw with a width already present | unchanged, draws on the first call |
| zero-width draw | skipped, redrawn once the element is sized |

The retry cap is a deliberate limit rather than a wait: after `maxDrawRetries` attempts the draw is abandoned, which leaves the collapsed rendering that occurs today rather than looping.
