### PR TITLE
layer: restore the position a hidden layer was moved away from

### DIFF
--- a/client/extjs-mod/Ext.Layer.js
+++ b/client/extjs-mod/Ext.Layer.js
@@ -272,7 +272,10 @@
             if(this.useDisplay === true) {
                 this.setDisplayed(false);
             } else {
-                this.setLeftTop(-10000,-10000);
+                // Park it with the Element method: this.setLeftTop would record
+                // -10000 as the position to restore, and showAction would then put
+                // the layer back off screen instead of where it was.
+                supr.setLeftTop.call(this, -10000, -10000);
             }
         },
 


### PR DESCRIPTION
## What happens

A dialog opens and cannot be seen. Its modal mask covers the interface, so the application is blocked, but the dialog itself is nowhere on screen. Reading the element shows it fully rendered and `visibility: visible` with real dimensions, sitting at `left: -10000px`.

Measured on such a dialog, in a 1920x1126 window:

| property | value |
|---|---|
| `style.left` | `-10000px` |
| `style.top` | `44px` |
| size | 420x442 and 330x292 for the two open dialogs |
| `visibility` / `display` | `visible` / `block` |
| modal mask | `1920x1126`, shown |

## Why

`hideAction()` parks a hidden layer off screen through the layer's own `setLeftTop()`:

```js
hideAction: function() {
    this.visible = false;
    ...
    this.setLeftTop(-10000,-10000);
}
```

That method is the one which records where a layer should be restored to:

```js
setLeftTop: function(left, top) {
    ...
    delete this.lastXY;
    this.lastLT = [left, top];
}
```

So hiding a layer discards the position it was at and stores the parking position in its place. `showAction()` then restores exactly what it was given:

```js
} else if(this.lastLT) {
    supr.setLeftTop.call(this, this.lastLT[0], this.lastLT[1]);
}
```

The layer becomes visible again at `-10000`, which is where it was hidden, rather than where it was shown. Anything positioned by `setLeftTop` rather than `setXY` is affected, because `setXY` stores `lastXY` and that branch is taken first.

## The change

`hideAction()` now parks the element with the `Ext.Element` method instead of the layer's own, so the stored restore position is left untouched. One line.

## Verified

Against a live client:

| case | before | after |
|---|---|---|
| layer at `[300, 250]`, hidden, shown | returns to `[-10000, -10000]` | returns to `[300, 250]` |
| stored state while hidden | `lastXY` deleted, `lastLT` = `[-10000, -10000]` | `lastXY` = `[300, 250]`, `lastLT` unset |
| `Ext.Window` hidden and shown | — | returns to `[585, 329]`, unchanged |

The two behaviours were compared in the same session by parking one layer through each method, so the difference is the park call and nothing else.
