### PR TITLE
element: add the constrain offsets instead of testing them

### DIFF
--- a/client/extjs-mod/Ext.Element.js
+++ b/client/extjs-mod/Ext.Element.js
@@ -346,8 +346,10 @@
 
 				var s = el.getScroll();
 
-				vx += offsets.left + s.left ? s.left : 0;
-				vy += offsets.top + s.top ? s.top : 0 ;
+				// '+' binds tighter than '?:', so writing this without the brackets
+				// drops the offset from the sum and only tests it for truthiness.
+				vx += offsets.left + (s.left ? s.left : 0);
+				vy += offsets.top + (s.top ? s.top : 0);
 
 				vw -= offsets.right ? offsets.right : 0;
 				vh -= offsets.bottom ? offsets.bottom : 0;


### PR DESCRIPTION
## What happens

`getConstrainToXY()` is told to keep a region free at the edges through its `offsets` argument. Those offsets are ignored whenever the container is scrolled, so an element is constrained a few pixels into the area that was meant to stay clear.

## Why

The origin of the constraining region is built like this:

```js
vx += offsets.left + s.left ? s.left : 0;
vy += offsets.top + s.top ? s.top : 0 ;
```

`+` binds tighter than `?:`, so this parses as `vx += (offsets.left + s.left) ? s.left : 0`. The offset never reaches the sum; it only contributes to a truthiness test whose result is the scroll value. With no scroll the whole expression is `0` and the offset is lost as well.

Measured against a scrolled body with `offsets.left` of 20 and a scroll of 300, constraining a 200px wide element at a proposed x of 5000 in a 1500px viewport:

| | x |
|---|---|
| before | `1600` |
| after | `1620` |
| expected | `1620`, which is `1500 - 200 + 300 + 20` |

The difference is always the offset, so the error is small and grows with whatever offset the caller asked for.

## The change

Bracket the conditional so the offset is added to the scroll rather than tested against it.

## Verified

Same session, same call, before and after the change: `[5000, 100]` constrains to `[1600, 100]` before and `[1620, 100]` after, with the body scrolled to 300 and an `offsets.left` of 20. The arithmetic for each combination of offset and scroll was also compared against the intended form, which differs whenever an offset is passed.

This corrects the constrain arithmetic only. A menu placed far outside the window is a separate defect and is not addressed here: with no offsets and no scroll both forms evaluate to zero, so that case is unaffected either way.