### PR TITLE
mail: make sorting a list by category behave like every other sort

### DIFF
--- a/client/zarafa/mail/ui/MailGridColumnModel.js
+++ b/client/zarafa/mail/ui/MailGridColumnModel.js
@@ -275,6 +275,21 @@ Zarafa.mail.ui.MailGridColumnModel = Ext.extend(Zarafa.common.ui.grid.ColumnMode
 			renderer: Zarafa.common.ui.grid.Renderers.flag,
 			fixed: true,
 			tooltip: _('Sort by: flag')
+		},{
+			// Compact view renders the categories in the row body, so this
+			// column is hidden by default and exists to make the list sortable
+			// by category without leaving the compact layout - switch it on
+			// from the header menu, the way the Size column works.
+			// It must stay LAST: the grid persists per-column width and hidden
+			// state keyed by the column's ordinal position, so inserting a
+			// column further up would shift the saved state of every column
+			// after it.
+			header: _('Categories'),
+			dataIndex: 'categories',
+			width: 160,
+			hidden: true,
+			renderer: Zarafa.common.ui.grid.Renderers.categories,
+			tooltip: _('Sort by: Categories')
 		}];
 	},
 

--- a/client/zarafa/mail/ui/MailGridColumnModel.js
+++ b/client/zarafa/mail/ui/MailGridColumnModel.js
@@ -276,19 +276,24 @@ Zarafa.mail.ui.MailGridColumnModel = Ext.extend(Zarafa.common.ui.grid.ColumnMode
 			fixed: true,
 			tooltip: _('Sort by: flag')
 		},{
-			// Compact view renders the categories in the row body, so this
-			// column is hidden by default and exists to make the list sortable
-			// by category without leaving the compact layout - switch it on
-			// from the header menu, the way the Size column works.
+			// A sort handle, not a data column. Compact view already renders
+			// every mail's categories as chips in the row body, so rendering
+			// them here as well would show each one twice - this column exists
+			// only to give the compact layout a header to sort the list by
+			// category, which is why it is one of the narrow icon columns and
+			// draws nothing in its cells. Hidden until switched on from the
+			// header menu, the way the Size column is.
 			// It must stay LAST: the grid persists per-column width and hidden
 			// state keyed by the column's ordinal position, so inserting a
 			// column further up would shift the saved state of every column
 			// after it.
-			header: _('Categories'),
+			header: '<p class="icon_categories">&nbsp;<span class="title">' + _('Categories') + '</span></p>',
+			headerCls: 'zarafa-icon-column categories',
 			dataIndex: 'categories',
-			width: 160,
+			width: 24,
 			hidden: true,
-			renderer: Zarafa.common.ui.grid.Renderers.categories,
+			fixed: true,
+			renderer: function() { return ''; },
 			tooltip: _('Sort by: Categories')
 		}];
 	},

--- a/server/includes/core/class.operations.php
+++ b/server/includes/core/class.operations.php
@@ -13,6 +13,13 @@
  */
 class Operations {
 	/**
+	 * Number of table rows read per call while folding a multi-instance sort
+	 * back into one row per item. Large enough that an ordinary page needs a
+	 * single call, small enough that no single read is unbounded.
+	 */
+	private const MULTI_INSTANCE_CHUNK = 512;
+
+	/**
 	 * Gets the hierarchy list of all required stores.
 	 *
 	 * getHierarchyList builds an entire hierarchy list of all folders that should be shown in various places. Most importantly,
@@ -1452,6 +1459,13 @@ class Operations {
 			mapi_table_restrict($table, $restriction, TBL_BATCH);
 		}
 
+		/*
+		 * Read the row count while it still counts items. A multi-instance sort
+		 * (see below) makes the table report one row per value instead, which
+		 * would tell the client there are more items than it can ever be shown.
+		 */
+		$totalrowcount = mapi_table_getrowcount($table);
+
 		if (is_array($sort) && !empty($sort)) {
 			/*
 			 * If the sort array contains the PR_SUBJECT column we should change this to
@@ -1477,7 +1491,21 @@ class Operations {
 			mapi_table_sort($table, $sort, TBL_BATCH);
 		}
 
-		$rows = mapi_table_queryrows($table, $properties, $start, $rowcount);
+		/*
+		 * A multi-value property cannot be sorted on directly - the server
+		 * rejects it with MAPI_E_NO_SUPPORT - so parseSortOrder() asks for a
+		 * multi-instance sort instead, which emits one row per value. Sorting
+		 * the mail list on "categories" therefore returns a mail once per
+		 * category it carries. Fold those rows back into one row per item, so
+		 * such a sort behaves like every other one and the total below counts
+		 * items, not values.
+		 */
+		if (self::isMultiInstanceSort($sort)) {
+			$rows = $this->queryDeduplicatedRows($table, $properties, $start, $rowcount);
+		}
+		else {
+			$rows = mapi_table_queryrows($table, $properties, $start, $rowcount);
+		}
 
 		foreach ($rows as $row) {
 			$itemData = Conversion::mapMAPI2XML($properties, $row);
@@ -1511,9 +1539,118 @@ class Operations {
 		$data["page"] = [];
 		$data["page"]["start"] = $start;
 		$data["page"]["rowcount"] = $rowcount;
-		$data["page"]["totalrowcount"] = mapi_table_getrowcount($table);
+		$data["page"]["totalrowcount"] = $totalrowcount;
 
 		return $data;
+	}
+
+	/**
+	 * Tells whether a MAPI sort order asks the server for multiple instances of
+	 * an item - one row per value of a multi-value property.
+	 *
+	 * @param array|bool $sort The sort order handed to getTable()
+	 *
+	 * @return bool TRUE when at least one sort key carries MV_INSTANCE
+	 */
+	private static function isMultiInstanceSort($sort) {
+		if (!is_array($sort)) {
+			return false;
+		}
+
+		foreach (array_keys($sort) as $propTag) {
+			if (((int) $propTag & MV_INSTANCE) === MV_INSTANCE) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Reads one page of a multi-instance sorted table as one row per item.
+	 *
+	 * An item is kept at the position of the FIRST row it appears in, which is
+	 * its place under the first of its values in the sort direction - a mail
+	 * categorised "Anfrage; Zzz" sorts under "Anfrage" ascending, the way
+	 * Outlook shows it. The rows in between belong to items that sorted earlier
+	 * and are skipped.
+	 *
+	 * @param resource $table      The restricted and sorted MAPI table
+	 * @param array    $properties The set of properties to read per row
+	 * @param int      $start      Starting item (not row) to read from
+	 * @param int      $rowcount   Number of items to read
+	 *
+	 * @return array The rows for the requested page, in table order
+	 */
+	private function queryDeduplicatedRows($table, $properties, $start, $rowcount) {
+		$instanceCount = mapi_table_getrowcount($table);
+		$needed = $start + $rowcount;
+		if ($instanceCount < 1 || $needed < 1) {
+			return [];
+		}
+
+		/*
+		 * Pass one: walk the rows reading the entryid alone and remember the
+		 * first row each item appears in. Reading one narrow column is cheap,
+		 * and the walk stops as soon as the requested page has been located -
+		 * so the cost follows how far the user has scrolled, not how big the
+		 * folder is.
+		 */
+		$firstRowOfItem = [];
+		$offset = 0;
+		while ($offset < $instanceCount && count($firstRowOfItem) < $needed) {
+			$idRows = mapi_table_queryrows($table, [PR_ENTRYID], $offset, self::MULTI_INSTANCE_CHUNK);
+			if (empty($idRows)) {
+				break;
+			}
+
+			foreach ($idRows as $index => $idRow) {
+				if (!isset($idRow[PR_ENTRYID])) {
+					continue;
+				}
+
+				$item = bin2hex((string) $idRow[PR_ENTRYID]);
+				if (!isset($firstRowOfItem[$item])) {
+					$firstRowOfItem[$item] = $offset + $index;
+				}
+			}
+
+			$offset += count($idRows);
+		}
+
+		// Insertion order is ascending row order, so this is the order the
+		// client must end up with.
+		$wantedRows = array_slice(array_values($firstRowOfItem), $start, $rowcount);
+		if (empty($wantedRows)) {
+			return [];
+		}
+
+		/*
+		 * Pass two: read the full property set for the wanted rows only. They
+		 * are not contiguous - the rows in between belong to items that sorted
+		 * earlier - so walk the span they cover in chunks and keep what was
+		 * asked for.
+		 */
+		$wanted = array_flip($wantedRows);
+		$last = $wantedRows[count($wantedRows) - 1];
+		$rows = [];
+		$offset = $wantedRows[0];
+		while ($offset <= $last) {
+			$chunk = mapi_table_queryrows($table, $properties, $offset, min(self::MULTI_INSTANCE_CHUNK, $last - $offset + 1));
+			if (empty($chunk)) {
+				break;
+			}
+
+			foreach ($chunk as $index => $row) {
+				if (isset($wanted[$offset + $index])) {
+					$rows[] = $row;
+				}
+			}
+
+			$offset += count($chunk);
+		}
+
+		return $rows;
 	}
 
 	/**

--- a/server/includes/modules/class.listmodule.php
+++ b/server/includes/modules/class.listmodule.php
@@ -361,8 +361,15 @@ class ListModule extends Module {
 
 		unset($action["restriction"]);
 
-		// Sort
-		$this->parseSortOrder($action);
+		/*
+		 * Sort. Multi-instance is allowed for the same reason as in
+		 * messageList(): a multi-value property such as "categories" cannot be
+		 * sorted on any other way - the server rejects a plain multi-value sort
+		 * with MAPI_E_NO_SUPPORT, which reaches the user as "Error in search.
+		 * Try again." - and getTable() folds the extra rows back into one row
+		 * per item.
+		 */
+		$this->parseSortOrder($action, null, true);
 
 		// Create the data array, which will be sent back to the client
 		$data = [];


### PR DESCRIPTION
The mail list has had a sortable Categories column for as long as the categories feature has existed, but clicking it did not produce a usable list. A mail carrying more than one category was asked for once per category, and the item total the server reported counted those extra rows, so the grid was told there were more mails than paging could ever deliver.

The cause is that a multi-value property cannot be sorted on directly: the server rejects a plain `PT_MV_STRING8` sort order with `MAPI_E_NO_SUPPORT` (`0x80040102`). `ListModule::parseSortOrder()` works around that by setting `MVI_FLAG`, which asks for a multi-instance sort and emits one row per value. On a seeded inbox of 80 mails with 0 to 2 categories each, sorting on Categories returned 96 rows and reported `page.totalrowcount` as 96. The client keys its records by entryid, so the 16 duplicates collapsed on arrival and each page silently delivered fewer mails than it had asked for, while the scrollbar, the live scroll and the counters all worked from the inflated total.

This folds the extra rows back into one row per item in `Operations::getTable()`, which is where every list module already meets, so the mail list, the calendar list view, contacts, tasks and notes are all fixed by the same code. An item keeps the position of the first row it appears in, which is its place under the first of its values in the sort direction: a mail categorised `Anfrage; Zzz` sorts under `Anfrage` ascending, the way Outlook shows it.

The read is done in two passes so it stays cheap. Pass one walks the sorted table reading the entryid column alone and stops as soon as the requested page has been located, so the cost follows how far the user has scrolled rather than the size of the folder. Pass two reads the full property set for the located rows only. The row count is now taken before the sort is applied, while it still counts items rather than values, so the total the client is given is a total it can actually reach.

Two things then stood between the working sort and the user. Search results went through the one code path that did not allow multiple instances, so a plain multi-value sort order was built there and the rejection reached the user directly as *"Error in search. Try again. (The server does not support this method call)"*. That path now allows multi-instance too, which is safe because the extra rows are folded away again before the results are sent.

And the column itself was out of reach in the default layout. A Categories column only exists in the extended column set, which is used for bottom preview and no preview; right preview, the default, switches to the compact set, which has no Categories column at all, so in the layout most people use there was nothing to click. The compact set now carries one too, hidden until it is switched on from the header menu the way the Size column is.

In compact view that column is a sort handle rather than a data column: it is one of the narrow 24px icon columns beside Importance, Attachment and Flag, with the categories icon in its header and a renderer that draws nothing. Compact view already renders every mail's categories as chips in the row body, so a column that drew them again would show each one twice. It is appended last on purpose: the grid is stateful and Ext keys each column's saved width and hidden state by the column's ordinal position (`ColumnModel#setConfig` assigns `c.id = i`), so a column inserted further up would shift the stored state of every column after it.

## Verified

Measured on a gromox backend with a seeded inbox of 80 mails, 0 to 2 categories each:

| | `totalrowcount` | rows returned | mails delivered twice |
|---|---|---|---|
| before | 96 | 96 | 16 |
| after | 80 | 80 | 0 |

- **Order.** Each mail appears exactly once, grouped under its first category in the sort direction, in both directions. Ascending: uncategorised, then `Anfrage`, `Blue`, `Zzz Letzte`.
- **Paging.** The pages tile the folder with no gaps and no repeats, and concatenated they match a single unpaged request row for row. Checked for every column of the mail grid in both directions (26 combinations) and for page sizes 5, 7, 20 and 50.
- **Scattered instances.** Re-checked with each of the 80 mails carrying three categories spread across the whole sorted table, so the rows belonging to one page lie as far apart as they can. 240 instances, 80 items, pages still tile exactly.
- **Search.** A search for `QCASE` sorted by Categories returns 30 mails, 30 distinct, correctly grouped in both directions. Before the change the same request answered with the `MAPI_E_NO_SUPPORT` error dialog.
- **No regression.** Sorting by every other column is unchanged: same totals, same order, no duplicates. The non-multi-instance read path is untouched.
- **Columns.** The shipped `createDefaultColumns()` and `createCompactColumns()` bodies were evaluated and compared against master's: the extended set is the same set in the same order, and the compact set differs only by the new hidden entry at index 11, so no saved column state shifts. The compact column's own renderer was called and returns empty, so it adds no second copy of the chips.

## Notes

A mail with several categories is placed under the first of them in the sort direction, not under the whole concatenated string. That is what groups all `Anfrage` mail together regardless of what else it carries, and it is the only ordering the multi-instance sort can give. The Categories column keeps showing the categories in their stored order, so such a row reads `Yellow; Anfrage` while sitting in the `Anfrage` block.

Subject is also absent from the compact column set and is left that way. Only the Categories column is added there, because it is the one this PR makes sortable; giving compact view a Subject column is a separate question.