### PR TITLE
css: reduced motion must not turn every style change into a transition

### DIFF
--- a/client/resources/css/grommunio.css
+++ b/client/resources/css/grommunio.css
@@ -8547,10 +8547,13 @@ body.k-keyboard .zarafa-settings-category-tab:focus-visible {
   background-position: center center !important;
 }
 
-/* Honour the reduced motion preference */
+/* Honour the reduced motion preference. A zero duration, not a near-zero one: a
+ * 0.01ms transition of `all` still starts, and within one script task it has not
+ * advanced, so ExtJS reads back the old position or size right after writing the
+ * new one and places menus, dialogs and the calendar grid off the page. */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
-    transition-duration: 0.01ms !important;
-    animation-duration: 0.01ms !important;
+    transition-duration: 0s !important;
+    animation-duration: 0s !important;
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important; } }


### PR DESCRIPTION
## What happens

On a system that reports `prefers-reduced-motion: reduce`, a right-click on a folder leaves an empty white page with the context menu alone in a corner, dialogs open invisible behind their mask, and the calendar day view can collapse into slivers. Every RDP session whose client has "Menu and window animation" switched off reports reduced motion, so the same user sees it over Remote Desktop and not on their own desktop, in every browser.

## Why

The reduced-motion block sets `transition-duration: 0.01ms !important` on every element. With `transition-property` at its initial value `all`, that starts a transition for every property change, and within one script task the transition has not advanced: a synchronous `getBoundingClientRect()` or `offsetWidth` right after the write still returns the old value.

ExtJS 3.4 writes geometry and reads it back in the same task everywhere. `Ext.Element.translatePoints` computes the new `left` as `x - getXY() + style.left`, and `Ext.menu.Menu.showAt` positions the menu twice before showing it. Each call reads `getXY()` as the parked `-10000` while `style.left` already holds the previous result, so a menu asked for `x` lands at `x + 10000 + x` and the document grows around it. Focusing the menu then scrolls the root to reach it, which is the white page. `Ext.Window.doConstrain` reads the position `beforeShow` just wrote as `-10000` and leaves the dialog there. The calendar reads a body width of 0 right after sizing it.

Measured on an affected session: three `translatePoints` calls for one menu, `getXY()` returned `[-10000, -10000]` every time while the inline `left` went `-10000px` → `125px` → `10250px`, and the results were `125`, `10250`, `20375`.

## The change

`0s` instead of `0.01ms` for both durations. A zero combined duration does not start a transition, so the next read sees the write, and the block still removes every animation and transition for users who asked for that. The only `transitionend` listener, `ToastPlugin.dismissToast`, already has a 400 ms fallback timer, so nothing waits for an event that no longer fires.

## Verified

Reproduced with Chromium against a development stack with only `prefers-reduced-motion: reduce` emulated. A right-click at `150, 264` placed the menu at inline `left: 20450px`, grew the document to `20594 x 20948` and scrolled the root to `18674, 19822`; the "Open Shared Mails" dialog opened at inline `left: -10000px`. With this change the same run places the menu at `150, 264` and the dialog at `795, 417`, identical to a run without reduced motion. Confirmed in a Remote Desktop session whose browser reports `prefers-reduced-motion: reduce` against the same stack: the menu opens at the cursor, the dialog is visible, and the calendar day view has its columns, where the unchanged build shows the white page.